### PR TITLE
Enable automated npm publishing linked with GitHub releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,13 @@
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 
 version: 2
+defaults: &defaults
+  working_directory: ~/smart-faq
+  docker:
+    - image: circleci/node:8.0
 jobs:
-  build: # smart-faq
-    docker:
-      - image: circleci/node:8
-
-    working_directory: ~/smart-faq
-
+  build:
+    <<: *defaults
     steps:
       - checkout
 
@@ -30,8 +30,7 @@ jobs:
       - run: yarn test-ci
 
   deploy:
-    docker:
-      - image: circleci/node:8
+    <<: *defaults
     steps:
       - checkout
       # Download and cache dependencies
@@ -42,6 +41,23 @@ jobs:
           - v1-dependencies-
       - run: yarn && yarn build:bundle && yarn build:pages
 
+  publish:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Write NPM Token to ~/.npmrc
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+      - run:
+          name: Install dot-json package
+          command: yarn add dot-json --dev
+      - run:
+          name: Write version to package.json
+          command: $(yarn bin)/dot-json package.json version ${CIRCLE_TAG:1}
+      - run:
+          name: Publish to NPM
+          command: npm publish --access=public
+
 workflows:
   version: 2
   build-and-deploy:
@@ -51,5 +67,16 @@ workflows:
           requires:
             - build
           filters:
+            branches:
+              only: master
+  build-and-publish:
+    jobs:
+      - build
+      - publish:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/ # only valid version tags, e.g. v0.0.1, v12.3.5
             branches:
               only: master

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # smart-faq
 Smart FAQ
 
+App demo: [https://kiwicom.github.io/smart-faq/](https://kiwicom.github.io/smart-faq/)
+
 ## Translations
 
 - Check out [react-i18next](https://react.i18next.com/) and [i18next](https://www.i18next.com/) docs for more info.
 - [DOCs for Phraseapp](https://phraseapp.com/docs/) - where the translations are stored for translators
 - List of all supported languages is defined by file `i18n/languages.js`
 
-### How to contribute
-
-#### Translations
+### How to use translations in code
 
 - be declarative & use `Trans` component whenever it's possible: 
 ```
@@ -24,14 +24,21 @@ Smart FAQ
 - run `yarn translations:collect` to recollect all translations for all supported languages
 - provide translations for all keys with `__STRING_NOT_TRANSLATED__` as value
 
-### Build process
+## Build process
 
-#### Github Pages
+### Github Pages
 
 - After every merge into master, standalone version of this project is published using Github Pages 
 - Inspired by repository [Circle CI and Github Pages](https://github.com/Villanuevand/deployment-circleci-gh-pages) and further described on [Github](https://github.com/DevProgress/onboarding/wiki/Using-Circle-CI-with-Github-Pages-for-Continuous-Delivery)
+- Deployed on [https://github.com/kiwicom/smart-faq/](https://github.com/kiwicom/smart-faq/)
 
-### TO RE-FACTOR (when Orbit is ready)
+## Release
+
+Done automatically when you add new release on [Github](https://github.com/kiwicom/smart-faq/releases/new)
+
+- automatically updates package.json with correct version and publish changes into npm
+
+## TO RE-FACTOR (when Orbit is ready)
 - `Button`s at Intro page need to have bold text
 - `Need help?` needs to be re-factor to use the `Text` component from Orbit(currenty it's hardcoded CSS)
 - At `IntroPage`: replace the `history.push` onChange trigger with `Button` using a children of type `Link`(already merged in Orbit master but not published yet)


### PR DESCRIPTION
Closes #24 

Idea:

- Publishing is tightly coupled with GitHub releases https://github.com/kiwicom/smart-faq/releases
- Each time we create a new release, npm package is automatically published

As a result, we will gain clean changelog with descriptions of all changes.

I decided not to do `npm version patch` for each commit - it's not feasible when we are working simultaneously and it would lead to a large number of releases, but it might be possible after merging into master 🤔 