### PR TITLE
Added (full)screen transition animations + Card shadow. First iteration.

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "react-relay": "1.5.0",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
+    "react-transition-group": "^2.3.1",
     "relay-runtime": "1.5.0",
     "styled-jsx": "^2.2.5"
   }

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import css from 'styled-jsx/css';
 import { I18nextProvider } from 'react-i18next';
 
+import { transitionStyles } from './helpers/globalStyles';
 import initTranslation from './initTranslation';
 import Routes from './Routes';
 import { CloseContext } from './context/Close';
@@ -83,9 +84,11 @@ class App extends React.Component<Props> {
         <style jsx global>
           {style}
         </style>
+        <style jsx global>
+          {transitionStyles}
+        </style>
       </div>
     );
   }
 }
-
 export default App;

--- a/src/NoBookingPage/index.js
+++ b/src/NoBookingPage/index.js
@@ -25,7 +25,6 @@ const style = css`
   div.NoBookingPage .Body {
     display: flex;
     height: calc(100% - (64px));
-    scroll-y: none;
   }
   div.FAQ {
     width: 480px;

--- a/src/NoBookingPage/index.js
+++ b/src/NoBookingPage/index.js
@@ -1,9 +1,12 @@
 // @flow
 
-import { Route, Switch, MemoryRouter } from 'react-router-dom';
+import { withRouter, Route, Switch, MemoryRouter } from 'react-router-dom';
 import * as React from 'react';
 import css from 'styled-jsx/css';
+import idx from 'idx';
+import { TransitionGroup, CSSTransition } from 'react-transition-group';
 
+import { delayTime } from '../helpers/globalStyles';
 import ContentHeader from '../ContentHeader';
 import StaticFAQ from '../StaticFAQ';
 import FAQArticleDetail from '../StaticFAQ/FAQArticleDetail';
@@ -22,26 +25,50 @@ const style = css`
   div.NoBookingPage .Body {
     display: flex;
     height: calc(100% - (64px));
+    scroll-y: none;
   }
   div.FAQ {
     width: 480px;
   }
 `;
 
+const MyRoutes = withRouter(({ location }) => {
+  const slideRight = idx(location.state, _ => _.slideRight);
+  const slideClass = slideRight ? 'SFAQ-TR-slideRight' : 'SFAQ-TR-slideLeft';
+  return (
+    <TransitionGroup
+      className="transition-container"
+      childFactory={child =>
+        React.cloneElement(child, {
+          classNames: slideClass,
+        })
+      }
+    >
+      <CSSTransition
+        key={location.key}
+        classNames={slideClass}
+        timeout={{ enter: delayTime, exit: delayTime }}
+      >
+        <Switch location={location}>
+          <Route
+            exact
+            path={`${routeDefinitions.STATIC_FAQ}/:categoryId?`}
+            component={StaticFAQ}
+          />
+          <Route
+            exact
+            path={`${routeDefinitions.FAQ_ARTICLE}/:articleId`}
+            component={FAQArticleDetail}
+          />
+        </Switch>
+      </CSSTransition>
+    </TransitionGroup>
+  );
+});
+
 const FAQRoutes = (
   <MemoryRouter initialEntries={[routeDefinitions.STATIC_FAQ]} initialIndex={0}>
-    <Switch>
-      <Route
-        exact
-        path={`${routeDefinitions.STATIC_FAQ}/:categoryId?`}
-        component={StaticFAQ}
-      />
-      <Route
-        exact
-        path={`${routeDefinitions.FAQ_ARTICLE}/:articleId`}
-        component={FAQArticleDetail}
-      />
-    </Switch>
+    <MyRoutes />
   </MemoryRouter>
 );
 const NoBookingPage = () => {

--- a/src/StaticFAQ/BackArrow.js
+++ b/src/StaticFAQ/BackArrow.js
@@ -15,7 +15,7 @@ const BackArrow = ({ id }: Props) => {
     ? `${routeDefinitions.STATIC_FAQ}/${id}`
     : routeDefinitions.STATIC_FAQ;
   return (
-    <Link to={url}>
+    <Link to={{ pathname: url, state: { slideRight: true } }}>
       <div className="circle">
         <span className="chevron">
           <ChevronLeft width="12" height="16" fill="#171b1e" />

--- a/src/StaticFAQ/Breadcrumb.js
+++ b/src/StaticFAQ/Breadcrumb.js
@@ -32,7 +32,10 @@ const Breadcrumb = ({ breadcrumb, isCurrent }: Props) => {
       {isCurrent ? (
         title
       ) : (
-        <Link to={url} style={{ textDecoration: 'none' }}>
+        <Link
+          to={{ pathname: url, state: { slideRight: true } }}
+          style={{ textDecoration: 'none' }}
+        >
           {title}
         </Link>
       )}

--- a/src/common/Card.js
+++ b/src/common/Card.js
@@ -11,7 +11,12 @@ const styles = css`
     height: 100px;
     width: 100%;
     border-radius: 3px;
-    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.12);
+    box-shadow: 0px 3px 6px rgba(0, 0, 0, 0.06), 0px 3px 6px rgba(0, 0, 0, 0.09);
+    transition: box-shadow 0.25s ease-in-out;
+  }
+  .card:hover {
+    box-shadow: 0px 10px 20px rgba(0, 0, 0, 0.06),
+      0px 6px 6px rgba(0, 0, 0, 0.09);
   }
 `;
 

--- a/src/helpers/globalStyles.js
+++ b/src/helpers/globalStyles.js
@@ -1,0 +1,84 @@
+// @flow
+
+export const animationStyles = (delayTime: number) => `
+  @keyframes enterLeft {
+    0% {
+      -webkit-transform: translateX(400px);
+      transform: translateX(400px);
+      will-change: transform;
+    }
+    100% {
+      -webkit-transform: translateX(0px);
+      transform: translateX(0px);
+      will-change: transform;
+    }
+  }
+  @keyframes enterRight {
+    0% {
+      -webkit-transform: translateX(-400px);
+      transform: translateX(-400px);
+      will-change: transform;
+    }
+    100% {
+      -webkit-transform: translateX(0px);
+      transform: translateX(0px);
+      will-change: transform;
+    }
+  }
+
+  @keyframes exitLeft {
+    0% {
+      opacity: 1;
+      -webkit-transform: translateX(0px);
+      transform: translateX(0px);
+      will-change: transform;
+    }
+    100% {
+      opacity: 0;
+      -webkit-transform: translateX(-400px);
+      transform: translateX(-400px);
+      will-change: transform;
+    }
+  }
+  @keyframes exitRight {
+    0% {
+      //opacity: 1;
+      -webkit-transform: translateX(0px);
+      transform: translateX(0px);
+      will-change: transform;
+    }
+    100% {
+      //opacity: 0;
+      -webkit-transform: translateX(400px);
+      transform: translateX(400px);
+      will-change: transform;
+    }
+  }
+
+  .SFAQ-TR-slideLeft-enter {
+    animation: enterLeft ${delayTime}ms ease-in-out;
+  }
+
+  .SFAQ-TR-slideLeft-exit {
+    animation: exitLeft ${delayTime}ms ease-in-out;
+  }
+
+  .SFAQ-TR-slideRight-enter {
+    animation: enterRight ${delayTime}ms ease-in-out;
+  }
+
+  .SFAQ-TR-slideRight-exit {
+    animation: exitRight ${delayTime}ms ease-in-out;
+  }
+  .transition-container {
+    position: relative;
+  }
+  .transition-container div.static-faq {
+    top: 0;
+    left: 0;
+    position: absolute;
+  }
+`;
+
+export const delayTime = 350;
+export const transitionStyles = animationStyles(delayTime);

--- a/src/helpers/globalStyles.js
+++ b/src/helpers/globalStyles.js
@@ -42,13 +42,13 @@ export const animationStyles = (delayTime: number) => `
   }
   @keyframes exitRight {
     0% {
-      //opacity: 1;
+      opacity: 1;
       -webkit-transform: translateX(0px);
       transform: translateX(0px);
       will-change: transform;
     }
     100% {
-      //opacity: 0;
+      opacity: 0;
       -webkit-transform: translateX(400px);
       transform: translateX(400px);
       will-change: transform;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3356,7 +3356,7 @@ dom-converter@~0.1:
   dependencies:
     utila "~0.3"
 
-dom-helpers@^3.2.0:
+dom-helpers@^3.2.0, dom-helpers@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
@@ -8515,7 +8515,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -8865,6 +8865,14 @@ react-transition-group@^1.1.2:
     loose-envify "^1.3.1"
     prop-types "^15.5.6"
     warning "^3.0.0"
+
+react-transition-group@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.3.1.tgz#31d611b33e143a5e0f2d94c348e026a0f3b474b6"
+  dependencies:
+    dom-helpers "^3.3.1"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.1"
 
 react-treebeard@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Relates to #45 

This is a proposal for transitions **only** for the `NoBookingPage` so far. This thing is quite tricky imho. 

So in case  this approach has positive reviews I suggest to:

1. Add same approach to `ContentPage`'s FAQ.
2. Create new issues to deal with:

- Fix glitch at the end of a screen transition(see gif at second transition)
- Separate search box and breadcrumbs from main page + decorate them with `withRouter`. So they can have a separate transition and not be affected by main one.



![smartfaq-animation-glitch](https://user-images.githubusercontent.com/2466887/39435257-2d9ec9a2-4c9b-11e8-9155-905b1cd433aa.gif)

LiveURL: <url>LiveURL: https://kiwicomsmart-faq-phvkkkfqhz.now.sh
</url>
</url>
