### PR TITLE
Fix "FormatDate" to correctly show date in UTC

### DIFF
--- a/src/helpers/dateUtils.js
+++ b/src/helpers/dateUtils.js
@@ -12,7 +12,13 @@ type Props = {|
 |};
 
 export const FormatDate = ({ dateString }: Props) => {
-  const options = { weekday: 'short', month: 'short', day: 'numeric' };
+  const options = {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  };
+
   return (
     <LanguageContext.Consumer>
       {language => {


### PR DESCRIPTION
We need to always pass `timeZone: 'UTC'` to show dates correctly<br/><br/><br/><url>LiveURL: https://kiwicomsmart-faq-ffkzkasawe.now.sh
</url>