### PR TITLE
Removed force clicking in cypress

### DIFF
--- a/cypress/integration/Logged_out_static_FAQ.cy.js
+++ b/cypress/integration/Logged_out_static_FAQ.cy.js
@@ -11,7 +11,7 @@ describe('Display Static FAQ', () => {
       .get('[data-cy=faq-categories]')
       .find('a')
       .first()
-      .click({ force: true });
+      .click();
 
     cy.get('.signInOrBack span').contains('Back');
 
@@ -38,7 +38,7 @@ describe('Display Static FAQ', () => {
       .get('@faq-box')
       .find('[data-cy=faq-link]')
       .first()
-      .click({ force: true });
+      .click();
 
     cy
       .get('@faq-breadcrumbs')

--- a/src/StaticFAQ/FAQArticle.js
+++ b/src/StaticFAQ/FAQArticle.js
@@ -34,7 +34,7 @@ const FAQArticle = (props: Props) => (
         ? `/faq/search/article/${props.article.id}`
         : `/faq/${props.categoryId || ''}/article/${props.article.id}`
     }
-    style={{ textDecoration: 'none' }}
+    style={{ textDecoration: 'none', display: 'block' }}
   >
     <Card>
       <div>

--- a/src/StaticFAQ/FAQCategoryList.js
+++ b/src/StaticFAQ/FAQCategoryList.js
@@ -94,7 +94,7 @@ class FAQCategoryList extends React.Component<Props> {
               <Link
                 key={category.id}
                 to={`/faq/${category.id}`}
-                style={{ textDecoration: 'none' }}
+                style={{ textDecoration: 'none', display: 'block' }}
               >
                 <FAQCategory category={category} />
               </Link>


### PR DESCRIPTION
closes #278 
As far as I tested (its an inline style) I could not spot any difference<br/><br/><br/><url>LiveURL: https://smartfaq-cypress-refactoring-anchors.surge.sh</url>