### PR TITLE
added target=blank to all ArticleDetail links

### DIFF
--- a/src/common/Markdown.js
+++ b/src/common/Markdown.js
@@ -1,7 +1,8 @@
 // @flow
 import React from 'react';
+import MarkdownIt from 'markdown-it';
 
-const md = require('markdown-it')({
+const md = MarkdownIt({
   html: true,
   linkify: true,
   typographer: true,
@@ -11,8 +12,13 @@ type Props = {
   children: ?string,
 };
 
+const renderMarkdown = markdown => {
+  const domString = md.render(markdown);
+  return domString.replace('<a href=', '<a target="_blank" href=');
+};
+
 const Markdown = (props: Props) => (
-  <div dangerouslySetInnerHTML={{ __html: md.render(props.children) }} />
+  <div dangerouslySetInnerHTML={{ __html: renderMarkdown(props.children) }} />
 );
 
 export default Markdown;

--- a/src/common/Markdown.js
+++ b/src/common/Markdown.js
@@ -14,7 +14,7 @@ type Props = {
 
 const renderMarkdown = markdown => {
   const domString = md.render(markdown);
-  return domString.replace('<a href=', '<a target="_blank" href=');
+  return domString.replace(/<a href=/g, '<a target="_blank" href=');
 };
 
 const Markdown = (props: Props) => (

--- a/src/common/__tests__/Markdown.test.js
+++ b/src/common/__tests__/Markdown.test.js
@@ -8,7 +8,9 @@ describe('Markdown', () => {
   it('should match snapshot', () => {
     const result = mount(
       <Markdown>
-        # Hello World [this is my url](https://www.kiwi.com/)
+        # Hello World [this is my url](https://www.kiwi.com/) [this is my second
+        url](https://www.kiwi.com/) [and this is third
+        url](https://www.kiwi.com/)
       </Markdown>,
     );
     expect(result).toMatchSnapshot();

--- a/src/common/__tests__/Markdown.test.js
+++ b/src/common/__tests__/Markdown.test.js
@@ -6,7 +6,11 @@ import Markdown from '../Markdown';
 
 describe('Markdown', () => {
   it('should match snapshot', () => {
-    const result = mount(<Markdown># Hello World</Markdown>);
+    const result = mount(
+      <Markdown>
+        # Hello World [this is my url](https://www.kiwi.com/)
+      </Markdown>,
+    );
     expect(result).toMatchSnapshot();
   });
 });

--- a/src/common/__tests__/__snapshots__/Markdown.test.js.snap
+++ b/src/common/__tests__/__snapshots__/Markdown.test.js.snap
@@ -5,7 +5,7 @@ exports[`Markdown should match snapshot 1`] = `
   <div
     dangerouslySetInnerHTML={
       Object {
-        "__html": "<h1>Hello World <a target=\\"_blank\\" href=\\"https://www.kiwi.com/\\">this is my url</a></h1>
+        "__html": "<h1>Hello World <a target=\\"_blank\\" href=\\"https://www.kiwi.com/\\">this is my url</a> <a target=\\"_blank\\" href=\\"https://www.kiwi.com/\\">this is my second url</a> <a target=\\"_blank\\" href=\\"https://www.kiwi.com/\\">and this is third url</a></h1>
 ",
       }
     }

--- a/src/common/__tests__/__snapshots__/Markdown.test.js.snap
+++ b/src/common/__tests__/__snapshots__/Markdown.test.js.snap
@@ -5,7 +5,7 @@ exports[`Markdown should match snapshot 1`] = `
   <div
     dangerouslySetInnerHTML={
       Object {
-        "__html": "<h1>Hello World</h1>
+        "__html": "<h1>Hello World <a target=\\"_blank\\" href=\\"https://www.kiwi.com/\\">this is my url</a></h1>
 ",
       }
     }


### PR DESCRIPTION
I know this is not the best approach but I could just not get https://github.com/markdown-it/markdown-it/blob/master/docs/architecture.md#renderer to work.
But then again I dont see any potential problems with this solution, Im just inserting `target`. <br/><br/><br/><url>LiveURL: https://smartfaq-314-articleDetail-links.surge.sh</url>