### PR TITLE
Bug with Overlay layer in Safari

### DIFF
--- a/src/SingleBookingPage/bookingTypes/MulticityOverlay.js
+++ b/src/SingleBookingPage/bookingTypes/MulticityOverlay.js
@@ -68,14 +68,15 @@ class MulticityOverlay extends React.Component<Props, State> {
               align-items: flex-end;
               position: absolute;
               top: 0;
+              left: 0;
               width: 100%;
               height: inherit;
               background: linear-gradient(
                 to bottom,
-                rgba(225, 0, 0, 0),
-                rgba(225, 0, 0, 0),
-                rgba(245, 247, 249, 0.59),
-                rgb(245, 247, 249)
+                rgba(225, 0, 0, 0) 50%,
+                rgba(225, 0, 0, 0) 30%,
+                rgba(245, 247, 249, 0.59) 30%,
+                rgb(245, 247, 249) 100%
               );
             }
             .multicityOverlayIsActive {


### PR DESCRIPTION
Close #340 

- Fixed bug with Overlay layer in Safari (linear-gradient works with some differences).
<br/><br/><br/><url>LiveURL: https://smartfaq-340-safari-bug-collapse-multicity-trips.surge.sh</url>