### PR TITLE
require test-ci to run cypress

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
       - run: yarn
-      - run: 
+      - run:
           command: yarn start:ci
           background: true
       - run:
@@ -115,9 +115,11 @@ workflows:
           filters:
             branches:
               ignore: master
+          requires:
+            - test-ci
       - surge-deploy:
-         requires: 
-           - test-ci 
+         requires:
+           - test-ci
            - cypress-tests
          filters:
            branches:


### PR DESCRIPTION
test-ci is required to pass to run cypress<br/><br/><br/><url>LiveURL: https://smartfaq-test-ci-before-cypress.surge.sh</url>