### PR TITLE
refactor routing so router changes are propagated into url

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,19 +107,22 @@
   "dependencies": {
     "@kiwicom/orbit-components": "0.0.0-rc7",
     "babel-runtime": "^6.26.0",
+    "history": "4.7.2",
     "i18next": "10.5.0",
     "idx": "2.2.0",
     "isomorphic-fetch": "2.2.1",
     "luxon": "1.2.0",
     "markdown-it": "^8.4.1",
     "react-content-loader": "^3.1.2",
+    "react-event-listener": "0.6.1",
     "react-i18next": "7.4.0",
     "react-relay": "1.5.0",
     "react-responsive": "^4.1.0",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
     "relay-runtime": "1.5.0",
-    "styled-jsx": "^2.2.5"
+    "styled-jsx": "^2.2.5",
+    "url-search-params-polyfill": "4.0.1"
   },
   "peerDependencies": {
     "react": "16.3.2",

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@
 import * as React from 'react';
 import css from 'styled-jsx/css';
 import { I18nextProvider } from 'react-i18next';
+import 'url-search-params-polyfill';
 
 import initTranslation from './initTranslation';
 import Routes from './Routes';
@@ -46,7 +47,7 @@ type Props = {|
   locale: {},
   user: User,
   loginToken: ?string,
-  initialRoute: string,
+  route: string,
   onClose: () => void,
   onLogin: onLogin,
   onSocialLogin: onSocialLogin,
@@ -125,7 +126,7 @@ class App extends React.PureComponent<Props, State> {
                           wasSelected={this.state.urlBookingWasSelected}
                           setSelected={this.urlBookingSelected}
                         />
-                        <Routes initialRoute={this.props.initialRoute} />
+                        <Routes route={this.props.route} />
                       </ExtraInfoStateProvider>
                     </BookingStateProvider>
                   </SearchStateProvider>

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { Route, Switch, MemoryRouter } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import * as React from 'react';
 
 import Intro from './IntroPage';
@@ -9,14 +9,15 @@ import KiwiLogin from './KiwiLogin';
 import ForgottenPassword from './ForgottenPassword';
 import { CheckRecoveryLink, CheckMagicLink } from './EmailPage';
 import ContentPage from './common/layout/ContentPage';
+import QueryParamRouter from './helpers/QueryParamRouter';
 
 type Props = {|
-  initialRoute: string,
+  route: string,
 |};
 
 const Routes = (props: Props) => {
   return (
-    <MemoryRouter initialEntries={[props.initialRoute]} initialIndex={0}>
+    <QueryParamRouter route={props.route}>
       <Switch>
         <Route exact path="/" component={Intro} />
         <Route path="/sign-in" component={SignIn} />
@@ -30,7 +31,7 @@ const Routes = (props: Props) => {
           component={ContentPage}
         />
       </Switch>
-    </MemoryRouter>
+    </QueryParamRouter>
   );
 };
 

--- a/src/helpers/QueryParamRouter.js
+++ b/src/helpers/QueryParamRouter.js
@@ -1,0 +1,86 @@
+// @flow
+
+import * as React from 'react';
+import EventListener from 'react-event-listener';
+import { createMemoryHistory as createHistory } from 'history';
+import { Router } from 'react-router';
+
+type Props = {|
+  route: string,
+  children: React.Node,
+|};
+
+class QueryParamRouter extends React.Component<Props> {
+  history: {
+    push: string => void,
+  };
+  unlisten: () => void;
+
+  constructor(props: Props) {
+    super(props);
+
+    const history = createHistory({
+      initialEntries: [props.route],
+      initialIndex: 0,
+    });
+    this.unlisten = history.listen(this.onHistoryChange);
+    this.history = history;
+  }
+
+  componentDidMount() {
+    this.updateUrlParam(this.props.route);
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.route !== this.props.route) {
+      this.history.push(this.props.route);
+      this.updateUrlParam(this.props.route);
+    }
+  }
+
+  componentWillUnmount() {
+    this.unlisten();
+  }
+
+  updateUrlParam = (pathname: string) => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const location = window.location;
+    const params = new URLSearchParams(location.search);
+
+    if (pathname === params.get('help')) {
+      return;
+    }
+
+    params.set('help', pathname);
+
+    window.history.pushState(
+      {},
+      null,
+      `${location.pathname}?${params.toString()}`,
+    );
+  };
+
+  onPopStateChange = () => {
+    const location = window.location;
+    const params = new URLSearchParams(location.search);
+    this.history.push(params.get('help'));
+  };
+
+  onHistoryChange = (location: { pathname: string }) => {
+    this.updateUrlParam(location.pathname);
+  };
+
+  render() {
+    return (
+      <React.Fragment>
+        <EventListener target="window" onpopstate={this.onPopStateChange} />
+        <Router history={this.history}>{this.props.children}</Router>
+      </React.Fragment>
+    );
+  }
+}
+
+export default QueryParamRouter;

--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,7 @@ class Root extends React.Component<Props, State> {
   render() {
     const { helpQuery } = this.state;
     const language = 'en';
-    const initialRoute = helpQuery ? helpQuery : '/';
+    const route = helpQuery ? helpQuery : '/';
     return (
       <div className="root">
         <div
@@ -133,7 +133,7 @@ class Root extends React.Component<Props, State> {
             language={language}
             locale={enLocale}
             user={this.state.user}
-            initialRoute={initialRoute}
+            route={route}
             loginToken={this.state.loginToken}
           />
         )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,6 +60,13 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@babel/runtime@^7.0.0-beta.42":
+  version "7.0.0-beta.53"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.53.tgz#9df22ae34823ce89f790060594b83ee572e2c5d2"
+  dependencies:
+    core-js "^2.5.7"
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
@@ -3352,6 +3359,10 @@ core-js@^2.5.6:
   version "2.5.6"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.6.tgz#0fe6d45bf3cac3ac364a9d72de7576f4eb221b9d"
 
+core-js@^2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -5928,7 +5939,7 @@ he@1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
-history@^4.7.2:
+history@4.7.2, history@^4.7.2:
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/history/-/history-4.7.2.tgz#22b5c7f31633c5b8021c7f4a8a954ac139ee8d5b"
   dependencies:
@@ -9864,6 +9875,14 @@ react-error-overlay@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
 
+react-event-listener@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.6.1.tgz#41c7a80a66b398c27dd511e22712b02f3d4eccca"
+  dependencies:
+    "@babel/runtime" "^7.0.0-beta.42"
+    prop-types "^15.6.0"
+    warning "^4.0.1"
+
 react-fuzzy@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/react-fuzzy/-/react-fuzzy-0.5.2.tgz#fc13bf6f0b785e5fefe908724efebec4935eaefe"
@@ -10258,6 +10277,10 @@ regenerator-runtime@^0.10.5:
 regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+
+regenerator-runtime@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.0.tgz#8052ac952d85b10f3425192cd0c53f45cf65c6cb"
 
 regenerator-transform@^0.10.0:
   version "0.10.1"
@@ -12105,6 +12128,10 @@ url-regex@^3.0.0:
   dependencies:
     ip-regex "^1.0.1"
 
+url-search-params-polyfill@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-4.0.1.tgz#4eda68a5689eda19aff2287e65d98d6fb5f6bc11"
+
 url-template@^2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
@@ -12335,6 +12362,12 @@ walker@~1.0.5:
 warning@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
+
+warning@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.1.tgz#66ce376b7fbfe8a887c22bdf0e7349d73d397745"
   dependencies:
     loose-envify "^1.0.0"
 


### PR DESCRIPTION
After some iteration - my solution to the routing problem.

This should keep `?help` param and the current route in sync.

BREAKING CHANGE: "initialRoute" prop replaced by "route"

closes #468 <br/><br/><br/><url>LiveURL: https://smartfaq-refactor-url-routing.surge.sh</url>