### PR TITLE
fix: disable background scroll & show previously displayed booking

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
   "dependencies": {
     "@kiwicom/orbit-components": "0.0.0-rc7",
     "babel-runtime": "^6.26.0",
+    "classnames": "2.2.6",
     "history": "4.7.2",
     "i18next": "10.5.0",
     "idx": "2.2.0",

--- a/src/App.js
+++ b/src/App.js
@@ -3,10 +3,12 @@
 
 import * as React from 'react';
 import css from 'styled-jsx/css';
+import classNames from 'classnames';
 import { I18nextProvider } from 'react-i18next';
 import 'url-search-params-polyfill';
 
 import initTranslation from './initTranslation';
+import EnLocale from '../i18n/en/translation.json';
 import Routes from './Routes';
 import { CloseContext } from './context/Close';
 import { LanguageContext } from './context/Language';
@@ -21,6 +23,7 @@ import type { onLogin, onLogout, onSocialLogin, User } from './types';
 
 const style = css`
   .smartFAQ {
+    display: none;
     position: fixed;
     min-width: 480px;
     top: 0;
@@ -28,6 +31,9 @@ const style = css`
     right: 0;
     background-color: #fff;
     font-family: 'Roboto', sans-serif;
+  }
+  .smartFAQ.open {
+    display: block;
   }
   .smartFAQ * {
     box-sizing: border-box;
@@ -44,10 +50,10 @@ const style = css`
 
 type Props = {|
   language: string,
-  locale: {},
   user: User,
   loginToken: ?string,
   route: string,
+  isOpen: boolean,
   onClose: () => void,
   onLogin: onLogin,
   onSocialLogin: onSocialLogin,
@@ -77,7 +83,7 @@ class App extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
 
-    this.i18n = initTranslation(props.language, props.locale);
+    this.i18n = initTranslation(props.language, EnLocale);
     this.state = {
       urlBookingWasSelected: false,
       userContext: {
@@ -99,9 +105,13 @@ class App extends React.PureComponent<Props, State> {
   };
 
   renderApp() {
+    const { isOpen } = this.props;
+
     return (
       <div
-        className="smartFAQ"
+        className={classNames('smartFAQ', {
+          open: isOpen,
+        })}
         data-test="SmartFAQHelp"
         onKeyDown={this.onKeyDown}
       >
@@ -122,11 +132,15 @@ class App extends React.PureComponent<Props, State> {
                   <SearchStateProvider>
                     <BookingStateProvider onLogout={this.props.onLogout}>
                       <ExtraInfoStateProvider>
-                        <SelectUrlBooking
-                          wasSelected={this.state.urlBookingWasSelected}
-                          setSelected={this.urlBookingSelected}
-                        />
-                        <Routes route={this.props.route} />
+                        {isOpen && (
+                          <React.Fragment>
+                            <SelectUrlBooking
+                              wasSelected={this.state.urlBookingWasSelected}
+                              setSelected={this.urlBookingSelected}
+                            />
+                            <Routes route={this.props.route} />
+                          </React.Fragment>
+                        )}
                       </ExtraInfoStateProvider>
                     </BookingStateProvider>
                   </SearchStateProvider>
@@ -137,6 +151,13 @@ class App extends React.PureComponent<Props, State> {
         </ErrorBoundary>
         <style jsx global>
           {style}
+        </style>
+        <style jsx global>
+          {`
+            body {
+              overflow-y: ${isOpen ? 'hidden' : 'auto'};
+            }
+          `}
         </style>
       </div>
     );

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,6 @@ import Raven from 'raven-js';
 import KeenTracking from 'keen-tracking';
 
 import App from './App';
-import enLocale from '../i18n/en/translation.json';
 import { socialLogin } from './helpers/Auth';
 import { Requester } from './helpers/Requests';
 import type { User } from './types';
@@ -124,19 +123,17 @@ class Root extends React.Component<Props, State> {
         >
           Toggle SmartFAQ
         </div>
-        {this.state.open && (
-          <App
-            onClose={this.closeApp}
-            onLogin={this.onLogin}
-            onSocialLogin={this.onSocialLogin}
-            onLogout={this.onLogout}
-            language={language}
-            locale={enLocale}
-            user={this.state.user}
-            route={route}
-            loginToken={this.state.loginToken}
-          />
-        )}
+        <App
+          onClose={this.closeApp}
+          onLogin={this.onLogin}
+          onSocialLogin={this.onSocialLogin}
+          onLogout={this.onLogout}
+          language={language}
+          isOpen={this.state.open}
+          user={this.state.user}
+          route={route}
+          loginToken={this.state.loginToken}
+        />
         <style jsx global>
           {`
             body {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2916,6 +2916,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+
 classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"


### PR DESCRIPTION
fix #380, fix #383

- disables background scroll
- removes `locale` prop
- enables SmartFAQ to be always rendered with new `isOpen`=true/false prop, so contexts are preserved => previously displayed booking is displayed