### PR TITLE
fix: do not use section arg for "FAQCategory" query

### DIFF
--- a/src/StaticFAQ/FAQCategoryList.js
+++ b/src/StaticFAQ/FAQCategoryList.js
@@ -75,8 +75,8 @@ const queryRoot = graphql`
   }
 `;
 const querySubcategory = graphql`
-  query FAQCategoryListSubcategoryQuery($id: ID!, $section: FAQSection) {
-    FAQCategory(id: $id, section: $section) {
+  query FAQCategoryListSubcategoryQuery($id: ID!) {
+    FAQCategory(id: $id) {
       id
       title
       subcategories {
@@ -213,31 +213,20 @@ class RawFAQCategoryList extends React.Component<Props> {
 
     if (categoryId) {
       return (
-        <ExtraInfoState.Consumer>
-          {({ activeExtraInfoCategory }: ExtraInfoStateType) => (
-            <QueryRenderer
-              query={querySubcategory}
-              render={this.renderSubcategory}
-              variables={{
-                id: categoryId,
-                section: activeExtraInfoCategory ? null : section,
-              }}
-            />
-          )}
-        </ExtraInfoState.Consumer>
+        <QueryRenderer
+          query={querySubcategory}
+          render={this.renderSubcategory}
+          variables={{ id: categoryId }}
+        />
       );
     }
 
     return (
-      <ExtraInfoState.Consumer>
-        {({ activeExtraInfoCategory }: ExtraInfoStateType) => (
-          <QueryRenderer
-            query={queryRoot}
-            render={this.renderRootCategory}
-            variables={{ section: activeExtraInfoCategory ? null : section }}
-          />
-        )}
-      </ExtraInfoState.Consumer>
+      <QueryRenderer
+        query={queryRoot}
+        render={this.renderRootCategory}
+        variables={{ section }}
+      />
     );
   }
 }

--- a/src/StaticFAQ/__generated__/FAQCategoryListSubcategoryQuery.graphql.js
+++ b/src/StaticFAQ/__generated__/FAQCategoryListSubcategoryQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash c2a6c80e3e4572940fef1f8010871ac3
+ * @relayHash 9ec426cad58535a5aa43eb703b642aea
  */
 
 /* eslint-disable */
@@ -12,10 +12,8 @@ import type { ConcreteRequest } from 'relay-runtime';
 type Breadcrumbs_breadcrumbs$ref = any;
 type FAQArticle_article$ref = any;
 type FAQCategory_category$ref = any;
-export type FAQSection = ('BEFORE_BOOKING' | 'PAST_BOOKING' | 'UPCOMING_BOOKING' | 'URGENT_BOOKING' | '%future added value');
 export type FAQCategoryListSubcategoryQueryVariables = {|
   id: string,
-  section?: ?FAQSection,
 |};
 export type FAQCategoryListSubcategoryQueryResponse = {|
   +FAQCategory: ?{|
@@ -42,9 +40,8 @@ export type FAQCategoryListSubcategoryQueryResponse = {|
 /*
 query FAQCategoryListSubcategoryQuery(
   $id: ID!
-  $section: FAQSection
 ) {
-  FAQCategory(id: $id, section: $section) {
+  FAQCategory(id: $id) {
     id
     title
     subcategories {
@@ -88,12 +85,6 @@ var v0 = [
     "name": "id",
     "type": "ID!",
     "defaultValue": null
-  },
-  {
-    "kind": "LocalArgument",
-    "name": "section",
-    "type": "FAQSection",
-    "defaultValue": null
   }
 ],
 v1 = [
@@ -102,12 +93,6 @@ v1 = [
     "name": "id",
     "variableName": "id",
     "type": "ID!"
-  },
-  {
-    "kind": "Variable",
-    "name": "section",
-    "variableName": "section",
-    "type": "FAQSection"
   }
 ],
 v2 = {
@@ -140,7 +125,7 @@ return {
   "operationKind": "query",
   "name": "FAQCategoryListSubcategoryQuery",
   "id": null,
-  "text": "query FAQCategoryListSubcategoryQuery(\n  $id: ID!\n  $section: FAQSection\n) {\n  FAQCategory(id: $id, section: $section) {\n    id\n    title\n    subcategories {\n      id\n      title\n      ...FAQCategory_category\n    }\n    ancestors {\n      id\n      ...Breadcrumbs_breadcrumbs\n    }\n    FAQs {\n      id\n      ...FAQArticle_article\n    }\n  }\n}\n\nfragment FAQCategory_category on FAQCategory {\n  id\n  title\n  perex\n}\n\nfragment Breadcrumbs_breadcrumbs on FAQCategory {\n  id\n  title\n}\n\nfragment FAQArticle_article on FAQArticle {\n  id\n  title\n  perex\n}\n",
+  "text": "query FAQCategoryListSubcategoryQuery(\n  $id: ID!\n) {\n  FAQCategory(id: $id) {\n    id\n    title\n    subcategories {\n      id\n      title\n      ...FAQCategory_category\n    }\n    ancestors {\n      id\n      ...Breadcrumbs_breadcrumbs\n    }\n    FAQs {\n      id\n      ...FAQArticle_article\n    }\n  }\n}\n\nfragment FAQCategory_category on FAQCategory {\n  id\n  title\n  perex\n}\n\nfragment Breadcrumbs_breadcrumbs on FAQCategory {\n  id\n  title\n}\n\nfragment FAQArticle_article on FAQArticle {\n  id\n  title\n  perex\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -271,5 +256,5 @@ return {
   }
 };
 })();
-(node/*: any*/).hash = 'a9286b8e65fec70c1749d92656cf882a';
+(node/*: any*/).hash = '590348ef68c7088b7f065f880c2c0726';
 module.exports = node;


### PR DESCRIPTION
closes #552 

This should hide "section" categories (e.g. "After booking") from SmartFAQ - previously you could reveal them by clicking on "Boarding passes" button.

When clicking on Home, user is redirected back to his section

Will work as expected after this is merged: https://github.com/kiwicom/graphql/pull/286<br/><br/><br/><url>LiveURL: https://smartfaq-fix-section-for-boarding-passes.surge.sh</url>