### PR TITLE
fix: keep CIRCLE CI config to remove warnings in builds

### DIFF
--- a/scripts/deploy-ghpages.sh
+++ b/scripts/deploy-ghpages.sh
@@ -27,7 +27,7 @@ then
     git checkout gh-pages
     # delete any old site as we are going to replace it
     # Note: this explodes if there aren't any, so moving it here for now
-    git rm -rf .
+    git rm -rf . --except .circleci
 else
     git checkout --orphan gh-pages
 fi


### PR DESCRIPTION
This should remove the warning below:

<img width="1074" alt="screen shot 2018-07-26 at 16 03 04" src="https://user-images.githubusercontent.com/2174629/43267138-6d546f98-90ed-11e8-8bb3-6e455bed7d1c.png">
<br/><br/><br/><url>LiveURL: https://smartfaq-fix-circle-ci.surge.sh</url>