### PR TITLE
fix(readme): add analytics login events

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ These are the events being recorded. Note that additionally to these attributes 
 - Possible payloads
   - When smartFAQ is opened: `{ action: "clickOnHelp", loggedIn: true | false}`
   - When smartFAQ is closed: `{ action: "close", loggedIn: true | false, timeOpen: "number of seconds open"}`
+  - Login Strategies:
+    - Kiwi: `{ action: "clickOnLogin", loginType: "kiwi"}`
+    - Google: `{ action: "clickOnLogin", loginType: "google"}`
+    - Facebook: `{ action: "clickOnLogin", loginType: "facebook"}`
 
 #### Eventname "smartFAQBookingOverview"
 


### PR DESCRIPTION
I forgot to add the events to the readme in this PR https://github.com/kiwicom/smart-faq/pull/591<br/><br/><br/><url>LiveURL: https://smartfaq-add-events-readme.surge.sh</url>