### PR TITLE
feat(analytics): add events "more info" and download boarding pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ These are the events being recorded. Note that additionally to these attributes 
     - Kiwi: `{ action: "clickOnLogin", loginType: "kiwi"}`
     - Google: `{ action: "clickOnLogin", loginType: "google"}`
     - Facebook: `{ action: "clickOnLogin", loginType: "facebook"}`
+  - Downloading boarding pass: `{ action: "downloadBoardingPass" }`
+  - "More info" in boarding pass section is clicked: `{ action: "clickOnMoreInfoBoarding" }`
 
 #### Eventname "smartFAQBookingOverview"
 

--- a/src/StaticFAQ/FAQExtraInfo/BoardingPassesInfo/BoardingPassesDescription.js
+++ b/src/StaticFAQ/FAQExtraInfo/BoardingPassesInfo/BoardingPassesDescription.js
@@ -5,6 +5,7 @@ import idx from 'idx';
 import { graphql, createFragmentContainer } from 'react-relay';
 import { FlightDirect, Download } from '@kiwicom/orbit-components/lib/icons';
 
+import { simpleTracker } from '../../../helpers/analytics/trackers';
 import replaceWithCurrentDomain from '../../../helpers/replaceWithCurrentDomain';
 import type { BoardingPassesDescription as BoardingPassesDescriptionProps } from './__generated__/BoardingPassesDescription.graphql';
 
@@ -12,6 +13,16 @@ type Props = {|
   data: BoardingPassesDescriptionProps,
   mmbUrl: string,
 |};
+
+const moreInfoBoardingTracker = () =>
+  simpleTracker('smartFAQ', {
+    action: 'clickOnMoreInfoBoarding',
+  });
+
+const downloadBoardingPassTracker = () =>
+  simpleTracker('smartFAQ', {
+    action: 'downloadBoardingPass',
+  });
 
 const BoardingPassesDescription = ({ data, mmbUrl }: Props) => {
   if (data.leg === null) return null;
@@ -31,7 +42,12 @@ const BoardingPassesDescription = ({ data, mmbUrl }: Props) => {
         </p>
         <div className="info">
           {boardingPassUrl ? (
-            <a href={boardingPassUrl} target="_blank" className="download">
+            <a
+              href={boardingPassUrl}
+              onClick={downloadBoardingPassTracker}
+              target="_blank"
+              className="download"
+            >
               <Download size="medium" customColor="#00a991" />
               Download
             </a>
@@ -40,6 +56,7 @@ const BoardingPassesDescription = ({ data, mmbUrl }: Props) => {
           ) : (
             <a
               href={replaceWithCurrentDomain(mmbUrl)}
+              onClick={moreInfoBoardingTracker}
               target="_blank"
               className="moreInfo"
             >


### PR DESCRIPTION
references https://github.com/kiwicom/smart-faq/issues/637
<br/><url>LiveURL: https://smartfaq-add-more-analytics-events.surge.sh</url>