### PR TITLE
Fix boarding passes integration test

### DIFF
--- a/cypress/integration/BoardingPassesInfo.js
+++ b/cypress/integration/BoardingPassesInfo.js
@@ -31,6 +31,8 @@ describe('Boarding Passes Info', () => {
   });
 
   it('should show the previous root category after clicking home', () => {
+    cy.wait(2000);
+
     cy.getFirstFaqCategoryTitle().then($initialFaqCategoryTitle => {
       cy.get('[data-cy=btn-boarding-passes]').click();
 


### PR DESCRIPTION
I had to add wait to this test, because FAQs are rendered earlier then bookings and after bookings are fetched, FAQs related to them are displayed. It wasn't breaking before, because the FAQs corresponding to the upcoming trip were the same as in the initial render, but there are cases when it can brake (close departure date for trip and displaying urgent contact). Maybe we could also solve the root cause (try out React Suspense later 🙃) and avoid loading irrelevant FAQs. 