### PR TITLE
test: add cypress test verifying redirects on Sign In page

### DIFF
--- a/cypress/integration/SignInPageRedirects.js
+++ b/cypress/integration/SignInPageRedirects.js
@@ -1,0 +1,34 @@
+// @noflow
+/* global cy */
+
+import { Requester } from '../../src/helpers/Requests';
+
+describe('SignIn page redirects', () => {
+  before(() => {
+    cy.visit('/');
+    cy.get('[data-cy=btn-existent-booking]').click();
+  });
+
+  it('does nothing on reload without user interaction', () => {
+    cy.reload();
+    cy
+      .get('.SignIn')
+      .find('h1')
+      .contains('Sign in');
+    cy.get('[data-cy=link-kiwi-login]').should('exist');
+  });
+
+  it('redirect to FAQs with booking on reload with logged in user', async () => {
+    const email = Cypress.env('TEST_USER_EMAIL');
+    const password = Cypress.env('TEST_USER_PASSWORD');
+    const authorization = Cypress.env('KIWILOGIN_USER');
+
+    const loginToken = await Requester.login(email, password, authorization);
+    cy.setCookie('mockedLogin', loginToken);
+    cy.reload();
+
+    cy.get('[data-cy=link-kiwi-login]').should('not.exist');
+    cy.get('[data-cy=nearestBooking]').should('exist');
+    cy.get('[data-cy=faq-categories]').should('exist');
+  });
+});

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -20,6 +20,7 @@ module.exports = (on, config) => {
   // `config` is the resolved Cypress config
   require('dotenv').load();
 
+  config.env.KIWILOGIN_USER = process.env.KIWILOGIN_USER;
   config.env.TEST_USER_EMAIL = process.env.TEST_USER_EMAIL;
   config.env.TEST_USER_PASSWORD = process.env.TEST_USER_PASSWORD;
 

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,3 +1,4 @@
 // @noflow
 
+import 'babel-polyfill'; // eslint-disable-line import/no-extraneous-dependencies
 import './commands/';

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
     "babel-plugin-transform-flow-comments": "^6.22.0",
     "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",

--- a/src/helpers/Requests.js
+++ b/src/helpers/Requests.js
@@ -8,14 +8,15 @@ export const loginEndpoint = endPoints.authApiUrl + '/v1/user.login';
 export const socialLoginEndpoint =
   endPoints.authApiUrl + '/v1/oauth.getAuthorizationUrl';
 
-const USER = process.env.KIWILOGIN_USER || '';
+const USER = process.env.KIWILOGIN_USER;
 
 export const Requester = {
-  login: (login: string, password: string) =>
+  login: (login: string, password: string, authorization?: string) =>
     fetch(loginEndpoint, {
       method: 'post',
       headers: {
-        Authorization: 'Basic ' + window.btoa(`${USER}:`),
+        Authorization:
+          'Basic ' + window.btoa(`${USER || authorization || ''}:`),
         'Content-type': 'application/json',
       },
       body: JSON.stringify({


### PR DESCRIPTION
closes #603

My response to the social login redirection problem - since the actual problem was that user was not redirected when a page was reloaded after successful login, it's not about social login at all, but instead testing the redirect. Which should be good enough for now.<br/><br/><br/><url>LiveURL: https://smartfaq-add-cypress-test-redirect.surge.sh</url>