### PR TITLE
feat(hover-help-tooltip): add analytic event for hovering tooltip

### DIFF
--- a/src/StaticFAQ/FAQExtraInfo/BoardingPassesInfo/BoardingPassesDescription.js
+++ b/src/StaticFAQ/FAQExtraInfo/BoardingPassesInfo/BoardingPassesDescription.js
@@ -25,6 +25,11 @@ const moreInfoBoardingTracker = () =>
     action: 'clickOnMoreInfoBoarding',
   });
 
+const tooltipTracker = () =>
+  simpleTracker('smartFAQ', {
+    action: 'showTooltip',
+  });
+
 const downloadBoardingPassTracker = () =>
   simpleTracker('smartFAQ', {
     action: 'downloadBoardingPass',
@@ -59,6 +64,7 @@ const BoardingPassesDescription = ({ data, mmbUrl }: Props) => {
           <HoverHelpTooltip
             tooltip="You will have to check-in for free at the airport"
             placement="top"
+            tracker={tooltipTracker}
           >
             <Badge type="info" icon={<InformationCircle />}>
               Airport check-in

--- a/src/common/Tooltip/HoverHelpTooltip.js
+++ b/src/common/Tooltip/HoverHelpTooltip.js
@@ -9,6 +9,7 @@ import type { Props as HelpTooptipProps } from './HelpTooltip';
 type Props = HelpTooptipProps & {
   disabled: boolean,
   iconName: string,
+  tracker?: () => void,
 };
 
 type State = {
@@ -30,6 +31,7 @@ export default class HoverHelpTooltip extends PureComponent<Props, State> {
     if (!this.props.disabled) {
       this.setState({ opened: true });
     }
+    this.props.tracker && this.props.tracker();
   };
 
   hide = () => {


### PR DESCRIPTION
references #637

❌ do not merge until https://github.com/kiwicom/smart-faq/pull/709 is merged<br/><br/><br/><url>LiveURL: https://smartfaq-637-add-analytic-events.surge.sh</url>