### PR TITLE
remove nowrap for perex

### DIFF
--- a/src/StaticFAQ/FAQArticleRaw.js
+++ b/src/StaticFAQ/FAQArticleRaw.js
@@ -17,12 +17,10 @@ type Props = {|
 
 const style = css`
   .perex {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
     color: #7f91a8;
     line-height: 1.4;
     margin-top: 5px;
+    font-size: 12px;
   }
 `;
 


### PR DESCRIPTION
should fix second comment https://gitlab.skypicker.com/frontend/frontend/merge_requests/5849#note_784217

I decided to remove all `...` as we had planned since the start, we were using it only because perexes were too long, but now content guys looks like they fixed it to the correct amount of characters, so we can remove `...` and use two lines as it is in the zeplin desings.  <br/><br/><br/><url>LiveURL: https://smartfaq-fix-perex-faqs.surge.sh</url>