### PR TITLE
feat(chat): use GraphQL to determine when chat should be displayed

### DIFF
--- a/cypress/fixtures/BookingOneWayResponse.js
+++ b/cypress/fixtures/BookingOneWayResponse.js
@@ -80,6 +80,9 @@ export default (departureTime, guaranteeBy) => ({
           },
         ],
       },
+      customerSupport: {
+        hasGuaranteeChat: guaranteeBy === 'KIWICOM',
+      },
       type: 'ONE_WAY',
       upcomingLeg: {
         arrival: {

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,5 +1,5 @@
 # source: https://graphql.kiwi.com
-# timestamp: Mon Sep 10 2018 12:03:21 GMT+0300 (EEST)
+# timestamp: Tue Sep 25 2018 17:25:12 GMT+0200 (CEST)
 
 schema {
   query: RootQuery
@@ -230,6 +230,9 @@ type Booking {
 
   """All services provided via whitelabels."""
   availableWhitelabeledServices: WhitelabeledServices
+
+  """Support provided by CS for booking."""
+  customerSupport: BookingCustomerSupport
   onlineCheckinIsAvailable: Boolean
   insurancePrices: [InsurancePrice]
   authToken: String
@@ -284,6 +287,13 @@ type BookingContactDetails {
 
   """Documentation and information about the passanger."""
   passenger: Passenger
+}
+
+type BookingCustomerSupport {
+  """
+  Is Guarantee Chat allowed to provide direct contact to customer service.
+  """
+  hasGuaranteeChat: Boolean
 }
 
 enum BookingDestinationImageDimensions {
@@ -346,6 +356,9 @@ interface BookingInterface {
 
   """All services provided via whitelabels."""
   availableWhitelabeledServices: WhitelabeledServices
+
+  """Support provided by CS for booking."""
+  customerSupport: BookingCustomerSupport
   onlineCheckinIsAvailable: Boolean
   insurancePrices: [InsurancePrice]
   authToken: String
@@ -414,6 +427,9 @@ type BookingMulticity implements BookingInterface & Node {
 
   """All services provided via whitelabels."""
   availableWhitelabeledServices: WhitelabeledServices
+
+  """Support provided by CS for booking."""
+  customerSupport: BookingCustomerSupport
   onlineCheckinIsAvailable: Boolean
   insurancePrices: [InsurancePrice]
   authToken: String
@@ -476,6 +492,9 @@ type BookingOneWay implements BookingInterface & Node {
 
   """All services provided via whitelabels."""
   availableWhitelabeledServices: WhitelabeledServices
+
+  """Support provided by CS for booking."""
+  customerSupport: BookingCustomerSupport
   onlineCheckinIsAvailable: Boolean
   insurancePrices: [InsurancePrice]
   authToken: String
@@ -528,6 +547,9 @@ type BookingReturn implements BookingInterface & Node {
 
   """All services provided via whitelabels."""
   availableWhitelabeledServices: WhitelabeledServices
+
+  """Support provided by CS for booking."""
+  customerSupport: BookingCustomerSupport
   onlineCheckinIsAvailable: Boolean
   insurancePrices: [InsurancePrice]
   authToken: String
@@ -1299,8 +1321,10 @@ type HotelAvailabilityEdge {
 Overall statistics related to all hotels matching search & filter criteria
 """
 type HotelAvailabilityStats {
-  priceMax: Float
-  priceMin: Float
+  priceMax: Float @deprecated(reason: "Use \"maxPrice\" field instead.")
+  priceMin: Float @deprecated(reason: "Use \"minPrice\" field instead.")
+  minPrice: Float
+  maxPrice: Float
 }
 
 type HotelCity {
@@ -2082,11 +2106,11 @@ type RootQuery {
     last: Int
   ): DynamicPackageConnection
 
-  """Retrieve list of FAQ categories."""
+  """
+  DEPRECATED - use "FAQSection" query instead.Retrieve list of FAQ categories.
+  """
   allFAQCategories(
-    """
-    Fetch only subsection of FAQ based on the current situation of customer.
-    """
+    """Fetch only subsection of FAQ based on customer's booking status."""
     section: FAQSection
     after: String
     first: Int
@@ -2201,6 +2225,14 @@ type RootQuery {
   FAQCategory(
     """ID of FAQ category to retrieve."""
     id: ID!
+  ): FAQCategory
+
+  """Retrieve category by section."""
+  FAQSection(
+    """
+    Fetch FAQ category by section according to current customer's booking status.
+    """
+    section: FAQSection!
   ): FAQCategory
 
   """Geography info by an IP address"""

--- a/src/MobileBookingHeader/__generated__/MobileNearestBookingQuery.graphql.js
+++ b/src/MobileBookingHeader/__generated__/MobileNearestBookingQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 706d01f03b691ed62a5302ee05e23e86
+ * @relayHash 305fb2baf1284dd32ad5d4908edabeef
  */
 
 /* eslint-disable */
@@ -70,10 +70,11 @@ fragment GuaranteeNeededResolver_booking on BookingInterface {
       lastname
     }
   }
+  customerSupport {
+    hasGuaranteeChat
+  }
   upcomingLeg(guarantee: KIWICOM) {
-    guarantee
     arrival {
-      time
       airport {
         city {
           name
@@ -83,7 +84,6 @@ fragment GuaranteeNeededResolver_booking on BookingInterface {
       }
     }
     departure {
-      time
       airport {
         city {
           name
@@ -171,13 +171,6 @@ var v0 = {
   "storageKey": null
 },
 v1 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "time",
-  "args": null,
-  "storageKey": null
-},
-v2 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "city",
@@ -195,8 +188,7 @@ v2 = {
     }
   ]
 },
-v3 = [
-  v1,
+v2 = [
   {
     "kind": "LinkedField",
     "alias": null,
@@ -206,7 +198,7 @@ v3 = [
     "concreteType": "Location",
     "plural": false,
     "selections": [
-      v2,
+      v1,
       {
         "kind": "ScalarField",
         "alias": null,
@@ -218,7 +210,7 @@ v3 = [
     ]
   }
 ],
-v4 = {
+v3 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "airport",
@@ -227,27 +219,14 @@ v4 = {
   "concreteType": "Location",
   "plural": false,
   "selections": [
-    v2,
+    v1,
     v0
   ]
 },
-v5 = {
-  "kind": "LinkedField",
-  "alias": null,
-  "name": "departure",
-  "storageKey": null,
-  "args": null,
-  "concreteType": "RouteStop",
-  "plural": false,
-  "selections": [
-    v4,
-    v1
-  ]
-},
-v6 = [
-  v4
+v4 = [
+  v3
 ],
-v7 = [
+v5 = [
   {
     "kind": "LinkedField",
     "alias": null,
@@ -256,15 +235,35 @@ v7 = [
     "args": null,
     "concreteType": "RouteStop",
     "plural": false,
-    "selections": v6
+    "selections": v4
   }
-];
+],
+v6 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "time",
+  "args": null,
+  "storageKey": null
+},
+v7 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "departure",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "RouteStop",
+  "plural": false,
+  "selections": [
+    v3,
+    v6
+  ]
+};
 return {
   "kind": "Request",
   "operationKind": "query",
   "name": "MobileNearestBookingQuery",
   "id": null,
-  "text": "query MobileNearestBookingQuery {\n  nearestBooking {\n    __typename\n    ...MobileBookingDetail_booking\n    ...GuaranteeNeededResolver_booking\n    id\n  }\n}\n\nfragment MobileBookingDetail_booking on BookingInterface {\n  type\n  databaseId\n  isPastBooking\n  directAccessURL\n  ... on BookingOneWay {\n    ...OneWayTripMobile_booking\n    trip {\n      departure {\n        time\n      }\n    }\n  }\n  ... on BookingReturn {\n    ...ReturnTripMobile_booking\n    outbound {\n      departure {\n        time\n      }\n    }\n  }\n  ... on BookingMulticity {\n    ...MultiCityTripMobile_booking\n    start {\n      time\n    }\n  }\n}\n\nfragment GuaranteeNeededResolver_booking on BookingInterface {\n  databaseId\n  status\n  contactDetails {\n    phone\n    email\n    passenger {\n      firstname\n      lastname\n    }\n  }\n  upcomingLeg(guarantee: KIWICOM) {\n    guarantee\n    arrival {\n      time\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    departure {\n      time\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment OneWayTripMobile_booking on BookingOneWay {\n  trip {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n    arrival {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ReturnTripMobile_booking on BookingReturn {\n  outbound {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n  inbound {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment MultiCityTripMobile_booking on BookingMulticity {\n  trips {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n  end {\n    airport {\n      city {\n        name\n      }\n      id\n    }\n  }\n}\n",
+  "text": "query MobileNearestBookingQuery {\n  nearestBooking {\n    __typename\n    ...MobileBookingDetail_booking\n    ...GuaranteeNeededResolver_booking\n    id\n  }\n}\n\nfragment MobileBookingDetail_booking on BookingInterface {\n  type\n  databaseId\n  isPastBooking\n  directAccessURL\n  ... on BookingOneWay {\n    ...OneWayTripMobile_booking\n    trip {\n      departure {\n        time\n      }\n    }\n  }\n  ... on BookingReturn {\n    ...ReturnTripMobile_booking\n    outbound {\n      departure {\n        time\n      }\n    }\n  }\n  ... on BookingMulticity {\n    ...MultiCityTripMobile_booking\n    start {\n      time\n    }\n  }\n}\n\nfragment GuaranteeNeededResolver_booking on BookingInterface {\n  databaseId\n  status\n  contactDetails {\n    phone\n    email\n    passenger {\n      firstname\n      lastname\n    }\n  }\n  customerSupport {\n    hasGuaranteeChat\n  }\n  upcomingLeg(guarantee: KIWICOM) {\n    arrival {\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    departure {\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment OneWayTripMobile_booking on BookingOneWay {\n  trip {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n    arrival {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ReturnTripMobile_booking on BookingReturn {\n  outbound {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n  inbound {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment MultiCityTripMobile_booking on BookingMulticity {\n  trips {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n  end {\n    airport {\n      city {\n        name\n      }\n      id\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -356,13 +355,6 @@ return {
             "plural": false,
             "selections": [
               {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "guarantee",
-                "args": null,
-                "storageKey": null
-              },
-              {
                 "kind": "LinkedField",
                 "alias": null,
                 "name": "arrival",
@@ -370,7 +362,7 @@ return {
                 "args": null,
                 "concreteType": "RouteStop",
                 "plural": false,
-                "selections": v3
+                "selections": v2
               },
               {
                 "kind": "LinkedField",
@@ -380,15 +372,40 @@ return {
                 "args": null,
                 "concreteType": "RouteStop",
                 "plural": false,
-                "selections": v3
+                "selections": v2
               },
               v0
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "customerSupport",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "BookingCustomerSupport",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "hasGuaranteeChat",
+                "args": null,
+                "storageKey": null
+              }
             ]
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "databaseId",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "status",
             "args": null,
             "storageKey": null
           },
@@ -443,37 +460,40 @@ return {
             ]
           },
           {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "status",
-            "args": null,
-            "storageKey": null
-          },
-          {
             "kind": "InlineFragment",
-            "type": "BookingReturn",
+            "type": "BookingMulticity",
             "selections": [
               {
                 "kind": "LinkedField",
                 "alias": null,
-                "name": "outbound",
+                "name": "trips",
                 "storageKey": null,
                 "args": null,
                 "concreteType": "Trip",
-                "plural": false,
-                "selections": [
-                  v5
-                ]
+                "plural": true,
+                "selections": v5
               },
               {
                 "kind": "LinkedField",
                 "alias": null,
-                "name": "inbound",
+                "name": "end",
                 "storageKey": null,
                 "args": null,
-                "concreteType": "Trip",
+                "concreteType": "RouteStop",
                 "plural": false,
-                "selections": v7
+                "selections": v4
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "start",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "RouteStop",
+                "plural": false,
+                "selections": [
+                  v6
+                ]
               }
             ]
           },
@@ -490,7 +510,7 @@ return {
                 "concreteType": "Trip",
                 "plural": false,
                 "selections": [
-                  v5,
+                  v7,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -499,7 +519,7 @@ return {
                     "args": null,
                     "concreteType": "RouteStop",
                     "plural": false,
-                    "selections": v6
+                    "selections": v4
                   }
                 ]
               }
@@ -507,39 +527,29 @@ return {
           },
           {
             "kind": "InlineFragment",
-            "type": "BookingMulticity",
+            "type": "BookingReturn",
             "selections": [
               {
                 "kind": "LinkedField",
                 "alias": null,
-                "name": "trips",
+                "name": "outbound",
                 "storageKey": null,
                 "args": null,
                 "concreteType": "Trip",
-                "plural": true,
-                "selections": v7
-              },
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "end",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "RouteStop",
-                "plural": false,
-                "selections": v6
-              },
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "start",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "RouteStop",
                 "plural": false,
                 "selections": [
-                  v1
+                  v7
                 ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "inbound",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Trip",
+                "plural": false,
+                "selections": v5
               }
             ]
           }

--- a/src/MobileBookingHeader/__generated__/MobileSelectedBookingQuery.graphql.js
+++ b/src/MobileBookingHeader/__generated__/MobileSelectedBookingQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash 41f40c28604df4f96b2b69c353317a77
+ * @relayHash b5aa367786ef6bb8841818217731f6fc
  */
 
 /* eslint-disable */
@@ -97,10 +97,11 @@ fragment GuaranteeNeededResolver_booking on BookingInterface {
       lastname
     }
   }
+  customerSupport {
+    hasGuaranteeChat
+  }
   upcomingLeg(guarantee: KIWICOM) {
-    guarantee
     arrival {
-      time
       airport {
         city {
           name
@@ -110,7 +111,6 @@ fragment GuaranteeNeededResolver_booking on BookingInterface {
       }
     }
     departure {
-      time
       airport {
         city {
           name
@@ -322,15 +322,7 @@ v12 = {
     }
   ]
 },
-v13 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "databaseId",
-  "args": null,
-  "storageKey": null
-},
-v14 = [
-  v9,
+v13 = [
   {
     "kind": "LinkedField",
     "alias": null,
@@ -352,7 +344,7 @@ v14 = [
     ]
   }
 ],
-v15 = {
+v14 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "upcomingLeg",
@@ -369,13 +361,6 @@ v15 = {
   "plural": false,
   "selections": [
     {
-      "kind": "ScalarField",
-      "alias": null,
-      "name": "guarantee",
-      "args": null,
-      "storageKey": null
-    },
-    {
       "kind": "LinkedField",
       "alias": null,
       "name": "arrival",
@@ -383,7 +368,7 @@ v15 = {
       "args": null,
       "concreteType": "RouteStop",
       "plural": false,
-      "selections": v14
+      "selections": v13
     },
     {
       "kind": "LinkedField",
@@ -393,10 +378,17 @@ v15 = {
       "args": null,
       "concreteType": "RouteStop",
       "plural": false,
-      "selections": v14
+      "selections": v13
     },
     v4
   ]
+},
+v15 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "databaseId",
+  "args": null,
+  "storageKey": null
 },
 v16 = {
   "kind": "ScalarField",
@@ -458,13 +450,19 @@ v17 = {
 v18 = {
   "kind": "LinkedField",
   "alias": null,
-  "name": "outbound",
+  "name": "customerSupport",
   "storageKey": null,
   "args": null,
-  "concreteType": "Trip",
+  "concreteType": "BookingCustomerSupport",
   "plural": false,
   "selections": [
-    v10
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "hasGuaranteeChat",
+      "args": null,
+      "storageKey": null
+    }
   ]
 },
 v19 = [
@@ -482,24 +480,6 @@ v19 = [
 v20 = {
   "kind": "LinkedField",
   "alias": null,
-  "name": "inbound",
-  "storageKey": null,
-  "args": null,
-  "concreteType": "Trip",
-  "plural": false,
-  "selections": v19
-},
-v21 = {
-  "kind": "InlineFragment",
-  "type": "BookingReturn",
-  "selections": [
-    v18,
-    v20
-  ]
-},
-v22 = {
-  "kind": "LinkedField",
-  "alias": null,
   "name": "trips",
   "storageKey": null,
   "args": null,
@@ -507,7 +487,7 @@ v22 = {
   "plural": true,
   "selections": v19
 },
-v23 = {
+v21 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "end",
@@ -517,7 +497,7 @@ v23 = {
   "plural": false,
   "selections": v11
 },
-v24 = {
+v22 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "start",
@@ -529,16 +509,46 @@ v24 = {
     v9
   ]
 },
-v25 = {
+v23 = {
   "kind": "InlineFragment",
   "type": "BookingMulticity",
   "selections": [
-    v22,
-    v23,
-    v24
+    v20,
+    v21,
+    v22
   ]
 },
+v24 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "outbound",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Trip",
+  "plural": false,
+  "selections": [
+    v10
+  ]
+},
+v25 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "inbound",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "Trip",
+  "plural": false,
+  "selections": v19
+},
 v26 = {
+  "kind": "InlineFragment",
+  "type": "BookingReturn",
+  "selections": [
+    v24,
+    v25
+  ]
+},
+v27 = {
   "kind": "InlineFragment",
   "type": "BookingOneWay",
   "selections": [
@@ -550,7 +560,7 @@ return {
   "operationKind": "query",
   "name": "MobileSelectedBookingQuery",
   "id": null,
-  "text": "query MobileSelectedBookingQuery(\n  $id: ID!\n) {\n  booking(id: $id) {\n    type\n    oneWay {\n      ...MobileBookingDetail_booking\n      ...GuaranteeNeededResolver_booking\n      id\n    }\n    return {\n      ...MobileBookingDetail_booking\n      ...GuaranteeNeededResolver_booking\n      id\n    }\n    multicity {\n      ...MobileBookingDetail_booking\n      ...GuaranteeNeededResolver_booking\n      id\n    }\n    id\n  }\n}\n\nfragment MobileBookingDetail_booking on BookingInterface {\n  type\n  databaseId\n  isPastBooking\n  directAccessURL\n  ... on BookingOneWay {\n    ...OneWayTripMobile_booking\n    trip {\n      departure {\n        time\n      }\n    }\n  }\n  ... on BookingReturn {\n    ...ReturnTripMobile_booking\n    outbound {\n      departure {\n        time\n      }\n    }\n  }\n  ... on BookingMulticity {\n    ...MultiCityTripMobile_booking\n    start {\n      time\n    }\n  }\n}\n\nfragment GuaranteeNeededResolver_booking on BookingInterface {\n  databaseId\n  status\n  contactDetails {\n    phone\n    email\n    passenger {\n      firstname\n      lastname\n    }\n  }\n  upcomingLeg(guarantee: KIWICOM) {\n    guarantee\n    arrival {\n      time\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    departure {\n      time\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment OneWayTripMobile_booking on BookingOneWay {\n  trip {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n    arrival {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ReturnTripMobile_booking on BookingReturn {\n  outbound {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n  inbound {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment MultiCityTripMobile_booking on BookingMulticity {\n  trips {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n  end {\n    airport {\n      city {\n        name\n      }\n      id\n    }\n  }\n}\n",
+  "text": "query MobileSelectedBookingQuery(\n  $id: ID!\n) {\n  booking(id: $id) {\n    type\n    oneWay {\n      ...MobileBookingDetail_booking\n      ...GuaranteeNeededResolver_booking\n      id\n    }\n    return {\n      ...MobileBookingDetail_booking\n      ...GuaranteeNeededResolver_booking\n      id\n    }\n    multicity {\n      ...MobileBookingDetail_booking\n      ...GuaranteeNeededResolver_booking\n      id\n    }\n    id\n  }\n}\n\nfragment MobileBookingDetail_booking on BookingInterface {\n  type\n  databaseId\n  isPastBooking\n  directAccessURL\n  ... on BookingOneWay {\n    ...OneWayTripMobile_booking\n    trip {\n      departure {\n        time\n      }\n    }\n  }\n  ... on BookingReturn {\n    ...ReturnTripMobile_booking\n    outbound {\n      departure {\n        time\n      }\n    }\n  }\n  ... on BookingMulticity {\n    ...MultiCityTripMobile_booking\n    start {\n      time\n    }\n  }\n}\n\nfragment GuaranteeNeededResolver_booking on BookingInterface {\n  databaseId\n  status\n  contactDetails {\n    phone\n    email\n    passenger {\n      firstname\n      lastname\n    }\n  }\n  customerSupport {\n    hasGuaranteeChat\n  }\n  upcomingLeg(guarantee: KIWICOM) {\n    arrival {\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    departure {\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment OneWayTripMobile_booking on BookingOneWay {\n  trip {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n    arrival {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ReturnTripMobile_booking on BookingReturn {\n  outbound {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n  inbound {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment MultiCityTripMobile_booking on BookingMulticity {\n  trips {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n  end {\n    airport {\n      city {\n        name\n      }\n      id\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -632,12 +642,13 @@ return {
               v5,
               v6,
               v12,
-              v13,
+              v14,
               v15,
               v16,
               v17,
-              v21,
-              v25
+              v18,
+              v23,
+              v26
             ]
           },
           {
@@ -649,18 +660,19 @@ return {
             "concreteType": "BookingReturn",
             "plural": false,
             "selections": [
-              v20,
+              v25,
               v2,
               v5,
               v6,
+              v14,
+              v24,
               v15,
               v18,
-              v13,
-              v17,
               v16,
+              v17,
               v4,
-              v26,
-              v25
+              v27,
+              v23
             ]
           },
           {
@@ -672,19 +684,20 @@ return {
             "concreteType": "BookingMulticity",
             "plural": false,
             "selections": [
-              v22,
+              v21,
               v2,
               v5,
               v6,
+              v14,
+              v18,
+              v20,
               v15,
-              v17,
-              v13,
-              v23,
-              v24,
+              v22,
               v16,
+              v17,
               v4,
-              v26,
-              v21
+              v27,
+              v26
             ]
           },
           v4

--- a/src/MobileBookingHeader/__generated__/MobileSelectedBookingSingleQuery.graphql.js
+++ b/src/MobileBookingHeader/__generated__/MobileSelectedBookingSingleQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash a3e7c646fd79bf909b0c35d5a8ad5398
+ * @relayHash 456bebe664f5b42e24ae5e7784dfcbd3
  */
 
 /* eslint-disable */
@@ -79,10 +79,11 @@ fragment GuaranteeNeededResolver_booking on BookingInterface {
       lastname
     }
   }
+  customerSupport {
+    hasGuaranteeChat
+  }
   upcomingLeg(guarantee: KIWICOM) {
-    guarantee
     arrival {
-      time
       airport {
         city {
           name
@@ -92,7 +93,6 @@ fragment GuaranteeNeededResolver_booking on BookingInterface {
       }
     }
     departure {
-      time
       airport {
         city {
           name
@@ -215,13 +215,6 @@ v3 = {
   "storageKey": null
 },
 v4 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "time",
-  "args": null,
-  "storageKey": null
-},
-v5 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "city",
@@ -239,8 +232,7 @@ v5 = {
     }
   ]
 },
-v6 = [
-  v4,
+v5 = [
   {
     "kind": "LinkedField",
     "alias": null,
@@ -250,7 +242,7 @@ v6 = [
     "concreteType": "Location",
     "plural": false,
     "selections": [
-      v5,
+      v4,
       {
         "kind": "ScalarField",
         "alias": null,
@@ -262,7 +254,7 @@ v6 = [
     ]
   }
 ],
-v7 = {
+v6 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "airport",
@@ -271,27 +263,14 @@ v7 = {
   "concreteType": "Location",
   "plural": false,
   "selections": [
-    v5,
+    v4,
     v3
   ]
 },
-v8 = {
-  "kind": "LinkedField",
-  "alias": null,
-  "name": "departure",
-  "storageKey": null,
-  "args": null,
-  "concreteType": "RouteStop",
-  "plural": false,
-  "selections": [
-    v7,
-    v4
-  ]
-},
-v9 = [
-  v7
+v7 = [
+  v6
 ],
-v10 = [
+v8 = [
   {
     "kind": "LinkedField",
     "alias": null,
@@ -300,15 +279,35 @@ v10 = [
     "args": null,
     "concreteType": "RouteStop",
     "plural": false,
-    "selections": v9
+    "selections": v7
   }
-];
+],
+v9 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "time",
+  "args": null,
+  "storageKey": null
+},
+v10 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "departure",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "RouteStop",
+  "plural": false,
+  "selections": [
+    v6,
+    v9
+  ]
+};
 return {
   "kind": "Request",
   "operationKind": "query",
   "name": "MobileSelectedBookingSingleQuery",
   "id": null,
-  "text": "query MobileSelectedBookingSingleQuery(\n  $id: Int!\n  $authToken: String!\n) {\n  singleBooking(id: $id, authToken: $authToken) {\n    __typename\n    type\n    ...MobileBookingDetail_booking\n    ...GuaranteeNeededResolver_booking\n    id\n  }\n}\n\nfragment MobileBookingDetail_booking on BookingInterface {\n  type\n  databaseId\n  isPastBooking\n  directAccessURL\n  ... on BookingOneWay {\n    ...OneWayTripMobile_booking\n    trip {\n      departure {\n        time\n      }\n    }\n  }\n  ... on BookingReturn {\n    ...ReturnTripMobile_booking\n    outbound {\n      departure {\n        time\n      }\n    }\n  }\n  ... on BookingMulticity {\n    ...MultiCityTripMobile_booking\n    start {\n      time\n    }\n  }\n}\n\nfragment GuaranteeNeededResolver_booking on BookingInterface {\n  databaseId\n  status\n  contactDetails {\n    phone\n    email\n    passenger {\n      firstname\n      lastname\n    }\n  }\n  upcomingLeg(guarantee: KIWICOM) {\n    guarantee\n    arrival {\n      time\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    departure {\n      time\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment OneWayTripMobile_booking on BookingOneWay {\n  trip {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n    arrival {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ReturnTripMobile_booking on BookingReturn {\n  outbound {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n  inbound {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment MultiCityTripMobile_booking on BookingMulticity {\n  trips {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n  end {\n    airport {\n      city {\n        name\n      }\n      id\n    }\n  }\n}\n",
+  "text": "query MobileSelectedBookingSingleQuery(\n  $id: Int!\n  $authToken: String!\n) {\n  singleBooking(id: $id, authToken: $authToken) {\n    __typename\n    type\n    ...MobileBookingDetail_booking\n    ...GuaranteeNeededResolver_booking\n    id\n  }\n}\n\nfragment MobileBookingDetail_booking on BookingInterface {\n  type\n  databaseId\n  isPastBooking\n  directAccessURL\n  ... on BookingOneWay {\n    ...OneWayTripMobile_booking\n    trip {\n      departure {\n        time\n      }\n    }\n  }\n  ... on BookingReturn {\n    ...ReturnTripMobile_booking\n    outbound {\n      departure {\n        time\n      }\n    }\n  }\n  ... on BookingMulticity {\n    ...MultiCityTripMobile_booking\n    start {\n      time\n    }\n  }\n}\n\nfragment GuaranteeNeededResolver_booking on BookingInterface {\n  databaseId\n  status\n  contactDetails {\n    phone\n    email\n    passenger {\n      firstname\n      lastname\n    }\n  }\n  customerSupport {\n    hasGuaranteeChat\n  }\n  upcomingLeg(guarantee: KIWICOM) {\n    arrival {\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    departure {\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment OneWayTripMobile_booking on BookingOneWay {\n  trip {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n    arrival {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ReturnTripMobile_booking on BookingReturn {\n  outbound {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n  inbound {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment MultiCityTripMobile_booking on BookingMulticity {\n  trips {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n  end {\n    airport {\n      city {\n        name\n      }\n      id\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -395,13 +394,6 @@ return {
             "plural": false,
             "selections": [
               {
-                "kind": "ScalarField",
-                "alias": null,
-                "name": "guarantee",
-                "args": null,
-                "storageKey": null
-              },
-              {
                 "kind": "LinkedField",
                 "alias": null,
                 "name": "arrival",
@@ -409,7 +401,7 @@ return {
                 "args": null,
                 "concreteType": "RouteStop",
                 "plural": false,
-                "selections": v6
+                "selections": v5
               },
               {
                 "kind": "LinkedField",
@@ -419,15 +411,40 @@ return {
                 "args": null,
                 "concreteType": "RouteStop",
                 "plural": false,
-                "selections": v6
+                "selections": v5
               },
               v3
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "customerSupport",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "BookingCustomerSupport",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "hasGuaranteeChat",
+                "args": null,
+                "storageKey": null
+              }
             ]
           },
           {
             "kind": "ScalarField",
             "alias": null,
             "name": "databaseId",
+            "args": null,
+            "storageKey": null
+          },
+          {
+            "kind": "ScalarField",
+            "alias": null,
+            "name": "status",
             "args": null,
             "storageKey": null
           },
@@ -482,37 +499,40 @@ return {
             ]
           },
           {
-            "kind": "ScalarField",
-            "alias": null,
-            "name": "status",
-            "args": null,
-            "storageKey": null
-          },
-          {
             "kind": "InlineFragment",
-            "type": "BookingReturn",
+            "type": "BookingMulticity",
             "selections": [
               {
                 "kind": "LinkedField",
                 "alias": null,
-                "name": "outbound",
+                "name": "trips",
                 "storageKey": null,
                 "args": null,
                 "concreteType": "Trip",
-                "plural": false,
-                "selections": [
-                  v8
-                ]
+                "plural": true,
+                "selections": v8
               },
               {
                 "kind": "LinkedField",
                 "alias": null,
-                "name": "inbound",
+                "name": "end",
                 "storageKey": null,
                 "args": null,
-                "concreteType": "Trip",
+                "concreteType": "RouteStop",
                 "plural": false,
-                "selections": v10
+                "selections": v7
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "start",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "RouteStop",
+                "plural": false,
+                "selections": [
+                  v9
+                ]
               }
             ]
           },
@@ -529,7 +549,7 @@ return {
                 "concreteType": "Trip",
                 "plural": false,
                 "selections": [
-                  v8,
+                  v10,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -538,7 +558,7 @@ return {
                     "args": null,
                     "concreteType": "RouteStop",
                     "plural": false,
-                    "selections": v9
+                    "selections": v7
                   }
                 ]
               }
@@ -546,39 +566,29 @@ return {
           },
           {
             "kind": "InlineFragment",
-            "type": "BookingMulticity",
+            "type": "BookingReturn",
             "selections": [
               {
                 "kind": "LinkedField",
                 "alias": null,
-                "name": "trips",
+                "name": "outbound",
                 "storageKey": null,
                 "args": null,
                 "concreteType": "Trip",
-                "plural": true,
-                "selections": v10
-              },
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "end",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "RouteStop",
-                "plural": false,
-                "selections": v9
-              },
-              {
-                "kind": "LinkedField",
-                "alias": null,
-                "name": "start",
-                "storageKey": null,
-                "args": null,
-                "concreteType": "RouteStop",
                 "plural": false,
                 "selections": [
-                  v4
+                  v10
                 ]
+              },
+              {
+                "kind": "LinkedField",
+                "alias": null,
+                "name": "inbound",
+                "storageKey": null,
+                "args": null,
+                "concreteType": "Trip",
+                "plural": false,
+                "selections": v8
               }
             ]
           }

--- a/src/SingleBookingPage/__generated__/NearestBookingQuery.graphql.js
+++ b/src/SingleBookingPage/__generated__/NearestBookingQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash abe57c7c363e0a7663b13d7eb6fbe7ab
+ * @relayHash b5202b05b41373f1af13f154fed21115
  */
 
 /* eslint-disable */
@@ -85,10 +85,11 @@ fragment GuaranteeNeededResolver_booking on BookingInterface {
       lastname
     }
   }
+  customerSupport {
+    hasGuaranteeChat
+  }
   upcomingLeg(guarantee: KIWICOM) {
-    guarantee
     arrival {
-      time
       airport {
         city {
           name
@@ -98,7 +99,6 @@ fragment GuaranteeNeededResolver_booking on BookingInterface {
       }
     }
     departure {
-      time
       airport {
         city {
           name
@@ -368,25 +368,11 @@ v1 = {
 v2 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "guarantee",
-  "args": null,
-  "storageKey": null
-},
-v3 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "time",
-  "args": null,
-  "storageKey": null
-},
-v4 = {
-  "kind": "ScalarField",
-  "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v5 = {
+v3 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "city",
@@ -395,18 +381,17 @@ v5 = {
   "concreteType": "LocationArea",
   "plural": false,
   "selections": [
-    v4
+    v2
   ]
 },
-v6 = {
+v4 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "code",
   "args": null,
   "storageKey": null
 },
-v7 = [
-  v3,
+v5 = [
   {
     "kind": "LinkedField",
     "alias": null,
@@ -416,20 +401,20 @@ v7 = [
     "concreteType": "Location",
     "plural": false,
     "selections": [
-      v5,
-      v6,
+      v3,
+      v4,
       v1
     ]
   }
 ],
-v8 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "locationId",
   "args": null,
   "storageKey": null
 },
-v9 = {
+v7 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "airport",
@@ -438,19 +423,26 @@ v9 = {
   "concreteType": "Location",
   "plural": false,
   "selections": [
-    v5,
+    v3,
     v1,
-    v8
+    v6
   ]
 },
-v10 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "localTime",
   "args": null,
   "storageKey": null
 },
-v11 = {
+v9 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "time",
+  "args": null,
+  "storageKey": null
+},
+v10 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "departure",
@@ -459,12 +451,12 @@ v11 = {
   "concreteType": "RouteStop",
   "plural": false,
   "selections": [
-    v9,
-    v10,
-    v3
+    v7,
+    v8,
+    v9
   ]
 },
-v12 = [
+v11 = [
   {
     "kind": "LinkedField",
     "alias": null,
@@ -474,23 +466,23 @@ v12 = [
     "concreteType": "Location",
     "plural": false,
     "selections": [
-      v4,
+      v2,
       v1,
-      v8,
-      v5
+      v6,
+      v3
     ]
   },
-  v10,
-  v3
+  v8,
+  v9
 ],
-v13 = {
+v12 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "duration",
   "args": null,
   "storageKey": null
 },
-v14 = {
+v13 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "legs",
@@ -515,8 +507,8 @@ v14 = {
       "concreteType": "Airline",
       "plural": false,
       "selections": [
+        v2,
         v4,
-        v6,
         {
           "kind": "ScalarField",
           "alias": null,
@@ -543,7 +535,7 @@ v14 = {
           "args": null,
           "storageKey": null
         },
-        v4
+        v2
       ]
     },
     {
@@ -586,7 +578,7 @@ v14 = {
       "args": null,
       "concreteType": "RouteStop",
       "plural": false,
-      "selections": v12
+      "selections": v11
     },
     {
       "kind": "LinkedField",
@@ -596,14 +588,20 @@ v14 = {
       "args": null,
       "concreteType": "RouteStop",
       "plural": false,
-      "selections": v12
+      "selections": v11
     },
-    v13,
-    v2,
+    v12,
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "guarantee",
+      "args": null,
+      "storageKey": null
+    },
     v1
   ]
 },
-v15 = {
+v14 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "airport",
@@ -612,8 +610,8 @@ v15 = {
   "concreteType": "Location",
   "plural": false,
   "selections": [
-    v8,
-    v5,
+    v6,
+    v3,
     v1
   ]
 };
@@ -622,7 +620,7 @@ return {
   "operationKind": "query",
   "name": "NearestBookingQuery",
   "id": null,
-  "text": "query NearestBookingQuery {\n  nearestBooking {\n    __typename\n    ...BookingDetail_booking\n    ...GuaranteeNeededResolver_booking\n    id\n  }\n}\n\nfragment BookingDetail_booking on BookingInterface {\n  type\n  status\n  assets {\n    ticketUrl\n  }\n  directAccessURL\n  isPastBooking\n  ...Header_booking\n  ... on BookingOneWay {\n    ...OneWayTrip_booking\n    trip {\n      departure {\n        time\n      }\n      arrival {\n        time\n      }\n    }\n  }\n  ... on BookingReturn {\n    ...ReturnTrip_booking\n    outbound {\n      departure {\n        time\n      }\n    }\n    inbound {\n      arrival {\n        time\n      }\n    }\n  }\n  ... on BookingMulticity {\n    ...MulticityOverlayTrip_booking\n    start {\n      time\n    }\n    end {\n      time\n    }\n  }\n}\n\nfragment GuaranteeNeededResolver_booking on BookingInterface {\n  databaseId\n  status\n  contactDetails {\n    phone\n    email\n    passenger {\n      firstname\n      lastname\n    }\n  }\n  upcomingLeg(guarantee: KIWICOM) {\n    guarantee\n    arrival {\n      time\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    departure {\n      time\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Header_booking on BookingInterface {\n  type\n  status\n  databaseId\n  ...OneWay_bookingHeader\n  ...Return_bookingHeader\n  ...Multicity_bookingHeader\n}\n\nfragment OneWayTrip_booking on BookingOneWay {\n  trip {\n    ...AccordionTripSummary_trip\n  }\n}\n\nfragment ReturnTrip_booking on BookingReturn {\n  outbound {\n    ...AccordionTripSummary_trip\n  }\n  inbound {\n    ...AccordionTripSummary_trip\n  }\n}\n\nfragment MulticityOverlayTrip_booking on BookingMulticity {\n  trips {\n    duration\n  }\n  ...MulticityTrip_booking\n}\n\nfragment MulticityTrip_booking on BookingMulticity {\n  trips {\n    ...AccordionTripSummary_trip\n  }\n}\n\nfragment AccordionTripSummary_trip on Trip {\n  departure {\n    localTime\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n  arrival {\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n  legs {\n    airline {\n      name\n      code\n      logoUrl\n    }\n    ...CarrierLogoWrapper_legs\n    ...AccordionBody_legs\n    id\n  }\n}\n\nfragment CarrierLogoWrapper_legs on Leg {\n  airline {\n    name\n    code\n  }\n}\n\nfragment AccordionBody_legs on Leg {\n  flightNumber\n  ...AccordionBodyLeg_leg\n  ...AccordionBodyLeg_nextLeg\n  ...AccordionBodyLastLeg_leg\n}\n\nfragment AccordionBodyLeg_leg on Leg {\n  ...AccordionLegCities_leg\n  ...AccordionLegTypeIcon_leg\n  arrival {\n    time\n    localTime\n  }\n  departure {\n    time\n    localTime\n  }\n}\n\nfragment AccordionBodyLeg_nextLeg on Leg {\n  departure {\n    time\n  }\n  guarantee\n}\n\nfragment AccordionBodyLastLeg_leg on Leg {\n  ...AccordionLegCities_leg\n  ...AccordionLegTypeIcon_leg\n  departure {\n    localTime\n  }\n}\n\nfragment AccordionLegCities_leg on Leg {\n  ...AccordionLegCitiesInfo_leg\n  type\n  duration\n  airline {\n    code\n    name\n  }\n  arrival {\n    localTime\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n  departure {\n    localTime\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n}\n\nfragment AccordionLegTypeIcon_leg on Leg {\n  type\n}\n\nfragment AccordionLegCitiesInfo_leg on Leg {\n  type\n  airline {\n    code\n    name\n  }\n  operatingAirline {\n    iata\n    name\n  }\n  flightNumber\n  vehicle {\n    manufacturer\n    model\n  }\n  pnr\n  departure {\n    airport {\n      name\n      id\n    }\n  }\n  arrival {\n    airport {\n      name\n      id\n    }\n  }\n}\n\nfragment OneWay_bookingHeader on BookingOneWay {\n  trip {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n    arrival {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Return_bookingHeader on BookingReturn {\n  outbound {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n    arrival {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Multicity_bookingHeader on BookingMulticity {\n  trips {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n  end {\n    airport {\n      city {\n        name\n      }\n      id\n    }\n  }\n}\n",
+  "text": "query NearestBookingQuery {\n  nearestBooking {\n    __typename\n    ...BookingDetail_booking\n    ...GuaranteeNeededResolver_booking\n    id\n  }\n}\n\nfragment BookingDetail_booking on BookingInterface {\n  type\n  status\n  assets {\n    ticketUrl\n  }\n  directAccessURL\n  isPastBooking\n  ...Header_booking\n  ... on BookingOneWay {\n    ...OneWayTrip_booking\n    trip {\n      departure {\n        time\n      }\n      arrival {\n        time\n      }\n    }\n  }\n  ... on BookingReturn {\n    ...ReturnTrip_booking\n    outbound {\n      departure {\n        time\n      }\n    }\n    inbound {\n      arrival {\n        time\n      }\n    }\n  }\n  ... on BookingMulticity {\n    ...MulticityOverlayTrip_booking\n    start {\n      time\n    }\n    end {\n      time\n    }\n  }\n}\n\nfragment GuaranteeNeededResolver_booking on BookingInterface {\n  databaseId\n  status\n  contactDetails {\n    phone\n    email\n    passenger {\n      firstname\n      lastname\n    }\n  }\n  customerSupport {\n    hasGuaranteeChat\n  }\n  upcomingLeg(guarantee: KIWICOM) {\n    arrival {\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    departure {\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Header_booking on BookingInterface {\n  type\n  status\n  databaseId\n  ...OneWay_bookingHeader\n  ...Return_bookingHeader\n  ...Multicity_bookingHeader\n}\n\nfragment OneWayTrip_booking on BookingOneWay {\n  trip {\n    ...AccordionTripSummary_trip\n  }\n}\n\nfragment ReturnTrip_booking on BookingReturn {\n  outbound {\n    ...AccordionTripSummary_trip\n  }\n  inbound {\n    ...AccordionTripSummary_trip\n  }\n}\n\nfragment MulticityOverlayTrip_booking on BookingMulticity {\n  trips {\n    duration\n  }\n  ...MulticityTrip_booking\n}\n\nfragment MulticityTrip_booking on BookingMulticity {\n  trips {\n    ...AccordionTripSummary_trip\n  }\n}\n\nfragment AccordionTripSummary_trip on Trip {\n  departure {\n    localTime\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n  arrival {\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n  legs {\n    airline {\n      name\n      code\n      logoUrl\n    }\n    ...CarrierLogoWrapper_legs\n    ...AccordionBody_legs\n    id\n  }\n}\n\nfragment CarrierLogoWrapper_legs on Leg {\n  airline {\n    name\n    code\n  }\n}\n\nfragment AccordionBody_legs on Leg {\n  flightNumber\n  ...AccordionBodyLeg_leg\n  ...AccordionBodyLeg_nextLeg\n  ...AccordionBodyLastLeg_leg\n}\n\nfragment AccordionBodyLeg_leg on Leg {\n  ...AccordionLegCities_leg\n  ...AccordionLegTypeIcon_leg\n  arrival {\n    time\n    localTime\n  }\n  departure {\n    time\n    localTime\n  }\n}\n\nfragment AccordionBodyLeg_nextLeg on Leg {\n  departure {\n    time\n  }\n  guarantee\n}\n\nfragment AccordionBodyLastLeg_leg on Leg {\n  ...AccordionLegCities_leg\n  ...AccordionLegTypeIcon_leg\n  departure {\n    localTime\n  }\n}\n\nfragment AccordionLegCities_leg on Leg {\n  ...AccordionLegCitiesInfo_leg\n  type\n  duration\n  airline {\n    code\n    name\n  }\n  arrival {\n    localTime\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n  departure {\n    localTime\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n}\n\nfragment AccordionLegTypeIcon_leg on Leg {\n  type\n}\n\nfragment AccordionLegCitiesInfo_leg on Leg {\n  type\n  airline {\n    code\n    name\n  }\n  operatingAirline {\n    iata\n    name\n  }\n  flightNumber\n  vehicle {\n    manufacturer\n    model\n  }\n  pnr\n  departure {\n    airport {\n      name\n      id\n    }\n  }\n  arrival {\n    airport {\n      name\n      id\n    }\n  }\n}\n\nfragment OneWay_bookingHeader on BookingOneWay {\n  trip {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n    arrival {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Return_bookingHeader on BookingReturn {\n  outbound {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n    arrival {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Multicity_bookingHeader on BookingMulticity {\n  trips {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n  end {\n    airport {\n      city {\n        name\n      }\n      id\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -739,7 +737,6 @@ return {
             "concreteType": "Leg",
             "plural": false,
             "selections": [
-              v2,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -748,7 +745,7 @@ return {
                 "args": null,
                 "concreteType": "RouteStop",
                 "plural": false,
-                "selections": v7
+                "selections": v5
               },
               {
                 "kind": "LinkedField",
@@ -758,9 +755,27 @@ return {
                 "args": null,
                 "concreteType": "RouteStop",
                 "plural": false,
-                "selections": v7
+                "selections": v5
               },
               v1
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "customerSupport",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "BookingCustomerSupport",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "hasGuaranteeChat",
+                "args": null,
+                "storageKey": null
+              }
             ]
           },
           {
@@ -826,7 +841,7 @@ return {
                 "concreteType": "Trip",
                 "plural": false,
                 "selections": [
-                  v11,
+                  v10,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -836,11 +851,11 @@ return {
                     "concreteType": "RouteStop",
                     "plural": false,
                     "selections": [
-                      v9,
-                      v3
+                      v7,
+                      v9
                     ]
                   },
-                  v14
+                  v13
                 ]
               }
             ]
@@ -858,7 +873,7 @@ return {
                 "concreteType": "Trip",
                 "plural": false,
                 "selections": [
-                  v11,
+                  v10,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -868,10 +883,10 @@ return {
                     "concreteType": "RouteStop",
                     "plural": false,
                     "selections": [
-                      v9
+                      v7
                     ]
                   },
-                  v14
+                  v13
                 ]
               },
               {
@@ -892,8 +907,8 @@ return {
                     "concreteType": "RouteStop",
                     "plural": false,
                     "selections": [
-                      v10,
-                      v15
+                      v8,
+                      v14
                     ]
                   },
                   {
@@ -905,11 +920,11 @@ return {
                     "concreteType": "RouteStop",
                     "plural": false,
                     "selections": [
-                      v15,
-                      v3
+                      v14,
+                      v9
                     ]
                   },
-                  v14
+                  v13
                 ]
               }
             ]
@@ -936,8 +951,8 @@ return {
                     "concreteType": "RouteStop",
                     "plural": false,
                     "selections": [
-                      v9,
-                      v10
+                      v7,
+                      v8
                     ]
                   },
                   {
@@ -949,10 +964,10 @@ return {
                     "concreteType": "RouteStop",
                     "plural": false,
                     "selections": [
-                      v15
+                      v14
                     ]
                   },
-                  v14
+                  v13
                 ]
               },
               {
@@ -973,11 +988,11 @@ return {
                     "concreteType": "Location",
                     "plural": false,
                     "selections": [
-                      v5,
+                      v3,
                       v1
                     ]
                   },
-                  v3
+                  v9
                 ]
               },
               {
@@ -989,7 +1004,7 @@ return {
                 "concreteType": "Trip",
                 "plural": true,
                 "selections": [
-                  v13
+                  v12
                 ]
               },
               {
@@ -1001,7 +1016,7 @@ return {
                 "concreteType": "RouteStop",
                 "plural": false,
                 "selections": [
-                  v3
+                  v9
                 ]
               }
             ]

--- a/src/SingleBookingPage/__generated__/SelectedBookingBySimpleTokenQuery.graphql.js
+++ b/src/SingleBookingPage/__generated__/SelectedBookingBySimpleTokenQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash f56537cea45eec4fab23d611c5933f2c
+ * @relayHash 0e7c080563702e9a557c0bccf6605920
  */
 
 /* eslint-disable */
@@ -94,10 +94,11 @@ fragment GuaranteeNeededResolver_booking on BookingInterface {
       lastname
     }
   }
+  customerSupport {
+    hasGuaranteeChat
+  }
   upcomingLeg(guarantee: KIWICOM) {
-    guarantee
     arrival {
-      time
       airport {
         city {
           name
@@ -107,7 +108,6 @@ fragment GuaranteeNeededResolver_booking on BookingInterface {
       }
     }
     departure {
-      time
       airport {
         city {
           name
@@ -405,25 +405,11 @@ v3 = {
 v4 = {
   "kind": "ScalarField",
   "alias": null,
-  "name": "guarantee",
-  "args": null,
-  "storageKey": null
-},
-v5 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "time",
-  "args": null,
-  "storageKey": null
-},
-v6 = {
-  "kind": "ScalarField",
-  "alias": null,
   "name": "name",
   "args": null,
   "storageKey": null
 },
-v7 = {
+v5 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "city",
@@ -432,18 +418,17 @@ v7 = {
   "concreteType": "LocationArea",
   "plural": false,
   "selections": [
-    v6
+    v4
   ]
 },
-v8 = {
+v6 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "code",
   "args": null,
   "storageKey": null
 },
-v9 = [
-  v5,
+v7 = [
   {
     "kind": "LinkedField",
     "alias": null,
@@ -453,20 +438,20 @@ v9 = [
     "concreteType": "Location",
     "plural": false,
     "selections": [
-      v7,
-      v8,
+      v5,
+      v6,
       v3
     ]
   }
 ],
-v10 = {
+v8 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "locationId",
   "args": null,
   "storageKey": null
 },
-v11 = {
+v9 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "airport",
@@ -475,19 +460,26 @@ v11 = {
   "concreteType": "Location",
   "plural": false,
   "selections": [
-    v7,
+    v5,
     v3,
-    v10
+    v8
   ]
 },
-v12 = {
+v10 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "localTime",
   "args": null,
   "storageKey": null
 },
-v13 = {
+v11 = {
+  "kind": "ScalarField",
+  "alias": null,
+  "name": "time",
+  "args": null,
+  "storageKey": null
+},
+v12 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "departure",
@@ -496,12 +488,12 @@ v13 = {
   "concreteType": "RouteStop",
   "plural": false,
   "selections": [
-    v11,
-    v12,
-    v5
+    v9,
+    v10,
+    v11
   ]
 },
-v14 = [
+v13 = [
   {
     "kind": "LinkedField",
     "alias": null,
@@ -511,23 +503,23 @@ v14 = [
     "concreteType": "Location",
     "plural": false,
     "selections": [
-      v6,
+      v4,
       v3,
-      v10,
-      v7
+      v8,
+      v5
     ]
   },
-  v12,
-  v5
+  v10,
+  v11
 ],
-v15 = {
+v14 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "duration",
   "args": null,
   "storageKey": null
 },
-v16 = {
+v15 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "legs",
@@ -552,8 +544,8 @@ v16 = {
       "concreteType": "Airline",
       "plural": false,
       "selections": [
+        v4,
         v6,
-        v8,
         {
           "kind": "ScalarField",
           "alias": null,
@@ -580,7 +572,7 @@ v16 = {
           "args": null,
           "storageKey": null
         },
-        v6
+        v4
       ]
     },
     {
@@ -623,7 +615,7 @@ v16 = {
       "args": null,
       "concreteType": "RouteStop",
       "plural": false,
-      "selections": v14
+      "selections": v13
     },
     {
       "kind": "LinkedField",
@@ -633,14 +625,20 @@ v16 = {
       "args": null,
       "concreteType": "RouteStop",
       "plural": false,
-      "selections": v14
+      "selections": v13
     },
-    v15,
-    v4,
+    v14,
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "guarantee",
+      "args": null,
+      "storageKey": null
+    },
     v3
   ]
 },
-v17 = {
+v16 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "airport",
@@ -649,8 +647,8 @@ v17 = {
   "concreteType": "Location",
   "plural": false,
   "selections": [
-    v10,
-    v7,
+    v8,
+    v5,
     v3
   ]
 };
@@ -659,7 +657,7 @@ return {
   "operationKind": "query",
   "name": "SelectedBookingBySimpleTokenQuery",
   "id": null,
-  "text": "query SelectedBookingBySimpleTokenQuery(\n  $id: Int!\n  $authToken: String!\n) {\n  singleBooking(id: $id, authToken: $authToken) {\n    __typename\n    type\n    ...BookingDetail_booking\n    ...GuaranteeNeededResolver_booking\n    id\n  }\n}\n\nfragment BookingDetail_booking on BookingInterface {\n  type\n  status\n  assets {\n    ticketUrl\n  }\n  directAccessURL\n  isPastBooking\n  ...Header_booking\n  ... on BookingOneWay {\n    ...OneWayTrip_booking\n    trip {\n      departure {\n        time\n      }\n      arrival {\n        time\n      }\n    }\n  }\n  ... on BookingReturn {\n    ...ReturnTrip_booking\n    outbound {\n      departure {\n        time\n      }\n    }\n    inbound {\n      arrival {\n        time\n      }\n    }\n  }\n  ... on BookingMulticity {\n    ...MulticityOverlayTrip_booking\n    start {\n      time\n    }\n    end {\n      time\n    }\n  }\n}\n\nfragment GuaranteeNeededResolver_booking on BookingInterface {\n  databaseId\n  status\n  contactDetails {\n    phone\n    email\n    passenger {\n      firstname\n      lastname\n    }\n  }\n  upcomingLeg(guarantee: KIWICOM) {\n    guarantee\n    arrival {\n      time\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    departure {\n      time\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Header_booking on BookingInterface {\n  type\n  status\n  databaseId\n  ...OneWay_bookingHeader\n  ...Return_bookingHeader\n  ...Multicity_bookingHeader\n}\n\nfragment OneWayTrip_booking on BookingOneWay {\n  trip {\n    ...AccordionTripSummary_trip\n  }\n}\n\nfragment ReturnTrip_booking on BookingReturn {\n  outbound {\n    ...AccordionTripSummary_trip\n  }\n  inbound {\n    ...AccordionTripSummary_trip\n  }\n}\n\nfragment MulticityOverlayTrip_booking on BookingMulticity {\n  trips {\n    duration\n  }\n  ...MulticityTrip_booking\n}\n\nfragment MulticityTrip_booking on BookingMulticity {\n  trips {\n    ...AccordionTripSummary_trip\n  }\n}\n\nfragment AccordionTripSummary_trip on Trip {\n  departure {\n    localTime\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n  arrival {\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n  legs {\n    airline {\n      name\n      code\n      logoUrl\n    }\n    ...CarrierLogoWrapper_legs\n    ...AccordionBody_legs\n    id\n  }\n}\n\nfragment CarrierLogoWrapper_legs on Leg {\n  airline {\n    name\n    code\n  }\n}\n\nfragment AccordionBody_legs on Leg {\n  flightNumber\n  ...AccordionBodyLeg_leg\n  ...AccordionBodyLeg_nextLeg\n  ...AccordionBodyLastLeg_leg\n}\n\nfragment AccordionBodyLeg_leg on Leg {\n  ...AccordionLegCities_leg\n  ...AccordionLegTypeIcon_leg\n  arrival {\n    time\n    localTime\n  }\n  departure {\n    time\n    localTime\n  }\n}\n\nfragment AccordionBodyLeg_nextLeg on Leg {\n  departure {\n    time\n  }\n  guarantee\n}\n\nfragment AccordionBodyLastLeg_leg on Leg {\n  ...AccordionLegCities_leg\n  ...AccordionLegTypeIcon_leg\n  departure {\n    localTime\n  }\n}\n\nfragment AccordionLegCities_leg on Leg {\n  ...AccordionLegCitiesInfo_leg\n  type\n  duration\n  airline {\n    code\n    name\n  }\n  arrival {\n    localTime\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n  departure {\n    localTime\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n}\n\nfragment AccordionLegTypeIcon_leg on Leg {\n  type\n}\n\nfragment AccordionLegCitiesInfo_leg on Leg {\n  type\n  airline {\n    code\n    name\n  }\n  operatingAirline {\n    iata\n    name\n  }\n  flightNumber\n  vehicle {\n    manufacturer\n    model\n  }\n  pnr\n  departure {\n    airport {\n      name\n      id\n    }\n  }\n  arrival {\n    airport {\n      name\n      id\n    }\n  }\n}\n\nfragment OneWay_bookingHeader on BookingOneWay {\n  trip {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n    arrival {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Return_bookingHeader on BookingReturn {\n  outbound {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n    arrival {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Multicity_bookingHeader on BookingMulticity {\n  trips {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n  end {\n    airport {\n      city {\n        name\n      }\n      id\n    }\n  }\n}\n",
+  "text": "query SelectedBookingBySimpleTokenQuery(\n  $id: Int!\n  $authToken: String!\n) {\n  singleBooking(id: $id, authToken: $authToken) {\n    __typename\n    type\n    ...BookingDetail_booking\n    ...GuaranteeNeededResolver_booking\n    id\n  }\n}\n\nfragment BookingDetail_booking on BookingInterface {\n  type\n  status\n  assets {\n    ticketUrl\n  }\n  directAccessURL\n  isPastBooking\n  ...Header_booking\n  ... on BookingOneWay {\n    ...OneWayTrip_booking\n    trip {\n      departure {\n        time\n      }\n      arrival {\n        time\n      }\n    }\n  }\n  ... on BookingReturn {\n    ...ReturnTrip_booking\n    outbound {\n      departure {\n        time\n      }\n    }\n    inbound {\n      arrival {\n        time\n      }\n    }\n  }\n  ... on BookingMulticity {\n    ...MulticityOverlayTrip_booking\n    start {\n      time\n    }\n    end {\n      time\n    }\n  }\n}\n\nfragment GuaranteeNeededResolver_booking on BookingInterface {\n  databaseId\n  status\n  contactDetails {\n    phone\n    email\n    passenger {\n      firstname\n      lastname\n    }\n  }\n  customerSupport {\n    hasGuaranteeChat\n  }\n  upcomingLeg(guarantee: KIWICOM) {\n    arrival {\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    departure {\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Header_booking on BookingInterface {\n  type\n  status\n  databaseId\n  ...OneWay_bookingHeader\n  ...Return_bookingHeader\n  ...Multicity_bookingHeader\n}\n\nfragment OneWayTrip_booking on BookingOneWay {\n  trip {\n    ...AccordionTripSummary_trip\n  }\n}\n\nfragment ReturnTrip_booking on BookingReturn {\n  outbound {\n    ...AccordionTripSummary_trip\n  }\n  inbound {\n    ...AccordionTripSummary_trip\n  }\n}\n\nfragment MulticityOverlayTrip_booking on BookingMulticity {\n  trips {\n    duration\n  }\n  ...MulticityTrip_booking\n}\n\nfragment MulticityTrip_booking on BookingMulticity {\n  trips {\n    ...AccordionTripSummary_trip\n  }\n}\n\nfragment AccordionTripSummary_trip on Trip {\n  departure {\n    localTime\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n  arrival {\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n  legs {\n    airline {\n      name\n      code\n      logoUrl\n    }\n    ...CarrierLogoWrapper_legs\n    ...AccordionBody_legs\n    id\n  }\n}\n\nfragment CarrierLogoWrapper_legs on Leg {\n  airline {\n    name\n    code\n  }\n}\n\nfragment AccordionBody_legs on Leg {\n  flightNumber\n  ...AccordionBodyLeg_leg\n  ...AccordionBodyLeg_nextLeg\n  ...AccordionBodyLastLeg_leg\n}\n\nfragment AccordionBodyLeg_leg on Leg {\n  ...AccordionLegCities_leg\n  ...AccordionLegTypeIcon_leg\n  arrival {\n    time\n    localTime\n  }\n  departure {\n    time\n    localTime\n  }\n}\n\nfragment AccordionBodyLeg_nextLeg on Leg {\n  departure {\n    time\n  }\n  guarantee\n}\n\nfragment AccordionBodyLastLeg_leg on Leg {\n  ...AccordionLegCities_leg\n  ...AccordionLegTypeIcon_leg\n  departure {\n    localTime\n  }\n}\n\nfragment AccordionLegCities_leg on Leg {\n  ...AccordionLegCitiesInfo_leg\n  type\n  duration\n  airline {\n    code\n    name\n  }\n  arrival {\n    localTime\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n  departure {\n    localTime\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n}\n\nfragment AccordionLegTypeIcon_leg on Leg {\n  type\n}\n\nfragment AccordionLegCitiesInfo_leg on Leg {\n  type\n  airline {\n    code\n    name\n  }\n  operatingAirline {\n    iata\n    name\n  }\n  flightNumber\n  vehicle {\n    manufacturer\n    model\n  }\n  pnr\n  departure {\n    airport {\n      name\n      id\n    }\n  }\n  arrival {\n    airport {\n      name\n      id\n    }\n  }\n}\n\nfragment OneWay_bookingHeader on BookingOneWay {\n  trip {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n    arrival {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Return_bookingHeader on BookingReturn {\n  outbound {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n    arrival {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Multicity_bookingHeader on BookingMulticity {\n  trips {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n  end {\n    airport {\n      city {\n        name\n      }\n      id\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -777,7 +775,6 @@ return {
             "concreteType": "Leg",
             "plural": false,
             "selections": [
-              v4,
               {
                 "kind": "LinkedField",
                 "alias": null,
@@ -786,7 +783,7 @@ return {
                 "args": null,
                 "concreteType": "RouteStop",
                 "plural": false,
-                "selections": v9
+                "selections": v7
               },
               {
                 "kind": "LinkedField",
@@ -796,9 +793,27 @@ return {
                 "args": null,
                 "concreteType": "RouteStop",
                 "plural": false,
-                "selections": v9
+                "selections": v7
               },
               v3
+            ]
+          },
+          {
+            "kind": "LinkedField",
+            "alias": null,
+            "name": "customerSupport",
+            "storageKey": null,
+            "args": null,
+            "concreteType": "BookingCustomerSupport",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "ScalarField",
+                "alias": null,
+                "name": "hasGuaranteeChat",
+                "args": null,
+                "storageKey": null
+              }
             ]
           },
           {
@@ -864,7 +879,7 @@ return {
                 "concreteType": "Trip",
                 "plural": false,
                 "selections": [
-                  v13,
+                  v12,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -874,11 +889,11 @@ return {
                     "concreteType": "RouteStop",
                     "plural": false,
                     "selections": [
-                      v11,
-                      v5
+                      v9,
+                      v11
                     ]
                   },
-                  v16
+                  v15
                 ]
               }
             ]
@@ -896,7 +911,7 @@ return {
                 "concreteType": "Trip",
                 "plural": false,
                 "selections": [
-                  v13,
+                  v12,
                   {
                     "kind": "LinkedField",
                     "alias": null,
@@ -906,10 +921,10 @@ return {
                     "concreteType": "RouteStop",
                     "plural": false,
                     "selections": [
-                      v11
+                      v9
                     ]
                   },
-                  v16
+                  v15
                 ]
               },
               {
@@ -930,8 +945,8 @@ return {
                     "concreteType": "RouteStop",
                     "plural": false,
                     "selections": [
-                      v12,
-                      v17
+                      v10,
+                      v16
                     ]
                   },
                   {
@@ -943,11 +958,11 @@ return {
                     "concreteType": "RouteStop",
                     "plural": false,
                     "selections": [
-                      v17,
-                      v5
+                      v16,
+                      v11
                     ]
                   },
-                  v16
+                  v15
                 ]
               }
             ]
@@ -974,8 +989,8 @@ return {
                     "concreteType": "RouteStop",
                     "plural": false,
                     "selections": [
-                      v11,
-                      v12
+                      v9,
+                      v10
                     ]
                   },
                   {
@@ -987,10 +1002,10 @@ return {
                     "concreteType": "RouteStop",
                     "plural": false,
                     "selections": [
-                      v17
+                      v16
                     ]
                   },
-                  v16
+                  v15
                 ]
               },
               {
@@ -1011,11 +1026,11 @@ return {
                     "concreteType": "Location",
                     "plural": false,
                     "selections": [
-                      v7,
+                      v5,
                       v3
                     ]
                   },
-                  v5
+                  v11
                 ]
               },
               {
@@ -1027,7 +1042,7 @@ return {
                 "concreteType": "Trip",
                 "plural": true,
                 "selections": [
-                  v15
+                  v14
                 ]
               },
               {
@@ -1039,7 +1054,7 @@ return {
                 "concreteType": "RouteStop",
                 "plural": false,
                 "selections": [
-                  v5
+                  v11
                 ]
               }
             ]

--- a/src/SingleBookingPage/__generated__/SelectedBookingQuery.graphql.js
+++ b/src/SingleBookingPage/__generated__/SelectedBookingQuery.graphql.js
@@ -1,6 +1,6 @@
 /**
  * @flow
- * @relayHash ca685d90d935a79db58e773db6d4ad96
+ * @relayHash 63222078360a56be3f39d201cff968f3
  */
 
 /* eslint-disable */
@@ -112,10 +112,11 @@ fragment GuaranteeNeededResolver_booking on BookingInterface {
       lastname
     }
   }
+  customerSupport {
+    hasGuaranteeChat
+  }
   upcomingLeg(guarantee: KIWICOM) {
-    guarantee
     arrival {
-      time
       airport {
         city {
           name
@@ -125,7 +126,6 @@ fragment GuaranteeNeededResolver_booking on BookingInterface {
       }
     }
     departure {
-      time
       airport {
         city {
           name
@@ -522,13 +522,6 @@ v14 = {
   "storageKey": null
 },
 v15 = {
-  "kind": "ScalarField",
-  "alias": null,
-  "name": "guarantee",
-  "args": null,
-  "storageKey": null
-},
-v16 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "legs",
@@ -637,11 +630,17 @@ v16 = {
       "selections": v13
     },
     v14,
-    v15,
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "guarantee",
+      "args": null,
+      "storageKey": null
+    },
     v6
   ]
 },
-v17 = {
+v16 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "trip",
@@ -664,10 +663,10 @@ v17 = {
         v10
       ]
     },
-    v16
+    v15
   ]
 },
-v18 = {
+v17 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "assets",
@@ -685,36 +684,35 @@ v18 = {
     }
   ]
 },
-v19 = {
+v18 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "directAccessURL",
   "args": null,
   "storageKey": null
 },
-v20 = {
+v19 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "isPastBooking",
   "args": null,
   "storageKey": null
 },
-v21 = {
+v20 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "databaseId",
   "args": null,
   "storageKey": null
 },
-v22 = {
+v21 = {
   "kind": "ScalarField",
   "alias": null,
   "name": "status",
   "args": null,
   "storageKey": null
 },
-v23 = [
-  v10,
+v22 = [
   {
     "kind": "LinkedField",
     "alias": null,
@@ -730,7 +728,7 @@ v23 = [
     ]
   }
 ],
-v24 = {
+v23 = {
   "kind": "LinkedField",
   "alias": null,
   "name": "upcomingLeg",
@@ -746,7 +744,6 @@ v24 = {
   "concreteType": "Leg",
   "plural": false,
   "selections": [
-    v15,
     {
       "kind": "LinkedField",
       "alias": null,
@@ -755,7 +752,7 @@ v24 = {
       "args": null,
       "concreteType": "RouteStop",
       "plural": false,
-      "selections": v23
+      "selections": v22
     },
     {
       "kind": "LinkedField",
@@ -765,9 +762,27 @@ v24 = {
       "args": null,
       "concreteType": "RouteStop",
       "plural": false,
-      "selections": v23
+      "selections": v22
     },
     v6
+  ]
+},
+v24 = {
+  "kind": "LinkedField",
+  "alias": null,
+  "name": "customerSupport",
+  "storageKey": null,
+  "args": null,
+  "concreteType": "BookingCustomerSupport",
+  "plural": false,
+  "selections": [
+    {
+      "kind": "ScalarField",
+      "alias": null,
+      "name": "hasGuaranteeChat",
+      "args": null,
+      "storageKey": null
+    }
   ]
 },
 v25 = {
@@ -842,7 +857,7 @@ v26 = {
         v8
       ]
     },
-    v16
+    v15
   ]
 },
 v27 = {
@@ -894,7 +909,7 @@ v28 = {
         v10
       ]
     },
-    v16
+    v15
   ]
 },
 v29 = {
@@ -939,7 +954,7 @@ v30 = {
         v27
       ]
     },
-    v16
+    v15
   ]
 },
 v31 = {
@@ -1005,7 +1020,7 @@ v35 = {
   "kind": "InlineFragment",
   "type": "BookingOneWay",
   "selections": [
-    v17
+    v16
   ]
 };
 return {
@@ -1013,7 +1028,7 @@ return {
   "operationKind": "query",
   "name": "SelectedBookingQuery",
   "id": null,
-  "text": "query SelectedBookingQuery(\n  $id: ID!\n) {\n  booking(id: $id) {\n    type\n    oneWay {\n      ...BookingDetail_booking\n      ...GuaranteeNeededResolver_booking\n      id\n    }\n    return {\n      ...BookingDetail_booking\n      ...GuaranteeNeededResolver_booking\n      id\n    }\n    multicity {\n      ...BookingDetail_booking\n      ...GuaranteeNeededResolver_booking\n      id\n    }\n    id\n  }\n}\n\nfragment BookingDetail_booking on BookingInterface {\n  type\n  status\n  assets {\n    ticketUrl\n  }\n  directAccessURL\n  isPastBooking\n  ...Header_booking\n  ... on BookingOneWay {\n    ...OneWayTrip_booking\n    trip {\n      departure {\n        time\n      }\n      arrival {\n        time\n      }\n    }\n  }\n  ... on BookingReturn {\n    ...ReturnTrip_booking\n    outbound {\n      departure {\n        time\n      }\n    }\n    inbound {\n      arrival {\n        time\n      }\n    }\n  }\n  ... on BookingMulticity {\n    ...MulticityOverlayTrip_booking\n    start {\n      time\n    }\n    end {\n      time\n    }\n  }\n}\n\nfragment GuaranteeNeededResolver_booking on BookingInterface {\n  databaseId\n  status\n  contactDetails {\n    phone\n    email\n    passenger {\n      firstname\n      lastname\n    }\n  }\n  upcomingLeg(guarantee: KIWICOM) {\n    guarantee\n    arrival {\n      time\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    departure {\n      time\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Header_booking on BookingInterface {\n  type\n  status\n  databaseId\n  ...OneWay_bookingHeader\n  ...Return_bookingHeader\n  ...Multicity_bookingHeader\n}\n\nfragment OneWayTrip_booking on BookingOneWay {\n  trip {\n    ...AccordionTripSummary_trip\n  }\n}\n\nfragment ReturnTrip_booking on BookingReturn {\n  outbound {\n    ...AccordionTripSummary_trip\n  }\n  inbound {\n    ...AccordionTripSummary_trip\n  }\n}\n\nfragment MulticityOverlayTrip_booking on BookingMulticity {\n  trips {\n    duration\n  }\n  ...MulticityTrip_booking\n}\n\nfragment MulticityTrip_booking on BookingMulticity {\n  trips {\n    ...AccordionTripSummary_trip\n  }\n}\n\nfragment AccordionTripSummary_trip on Trip {\n  departure {\n    localTime\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n  arrival {\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n  legs {\n    airline {\n      name\n      code\n      logoUrl\n    }\n    ...CarrierLogoWrapper_legs\n    ...AccordionBody_legs\n    id\n  }\n}\n\nfragment CarrierLogoWrapper_legs on Leg {\n  airline {\n    name\n    code\n  }\n}\n\nfragment AccordionBody_legs on Leg {\n  flightNumber\n  ...AccordionBodyLeg_leg\n  ...AccordionBodyLeg_nextLeg\n  ...AccordionBodyLastLeg_leg\n}\n\nfragment AccordionBodyLeg_leg on Leg {\n  ...AccordionLegCities_leg\n  ...AccordionLegTypeIcon_leg\n  arrival {\n    time\n    localTime\n  }\n  departure {\n    time\n    localTime\n  }\n}\n\nfragment AccordionBodyLeg_nextLeg on Leg {\n  departure {\n    time\n  }\n  guarantee\n}\n\nfragment AccordionBodyLastLeg_leg on Leg {\n  ...AccordionLegCities_leg\n  ...AccordionLegTypeIcon_leg\n  departure {\n    localTime\n  }\n}\n\nfragment AccordionLegCities_leg on Leg {\n  ...AccordionLegCitiesInfo_leg\n  type\n  duration\n  airline {\n    code\n    name\n  }\n  arrival {\n    localTime\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n  departure {\n    localTime\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n}\n\nfragment AccordionLegTypeIcon_leg on Leg {\n  type\n}\n\nfragment AccordionLegCitiesInfo_leg on Leg {\n  type\n  airline {\n    code\n    name\n  }\n  operatingAirline {\n    iata\n    name\n  }\n  flightNumber\n  vehicle {\n    manufacturer\n    model\n  }\n  pnr\n  departure {\n    airport {\n      name\n      id\n    }\n  }\n  arrival {\n    airport {\n      name\n      id\n    }\n  }\n}\n\nfragment OneWay_bookingHeader on BookingOneWay {\n  trip {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n    arrival {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Return_bookingHeader on BookingReturn {\n  outbound {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n    arrival {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Multicity_bookingHeader on BookingMulticity {\n  trips {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n  end {\n    airport {\n      city {\n        name\n      }\n      id\n    }\n  }\n}\n",
+  "text": "query SelectedBookingQuery(\n  $id: ID!\n) {\n  booking(id: $id) {\n    type\n    oneWay {\n      ...BookingDetail_booking\n      ...GuaranteeNeededResolver_booking\n      id\n    }\n    return {\n      ...BookingDetail_booking\n      ...GuaranteeNeededResolver_booking\n      id\n    }\n    multicity {\n      ...BookingDetail_booking\n      ...GuaranteeNeededResolver_booking\n      id\n    }\n    id\n  }\n}\n\nfragment BookingDetail_booking on BookingInterface {\n  type\n  status\n  assets {\n    ticketUrl\n  }\n  directAccessURL\n  isPastBooking\n  ...Header_booking\n  ... on BookingOneWay {\n    ...OneWayTrip_booking\n    trip {\n      departure {\n        time\n      }\n      arrival {\n        time\n      }\n    }\n  }\n  ... on BookingReturn {\n    ...ReturnTrip_booking\n    outbound {\n      departure {\n        time\n      }\n    }\n    inbound {\n      arrival {\n        time\n      }\n    }\n  }\n  ... on BookingMulticity {\n    ...MulticityOverlayTrip_booking\n    start {\n      time\n    }\n    end {\n      time\n    }\n  }\n}\n\nfragment GuaranteeNeededResolver_booking on BookingInterface {\n  databaseId\n  status\n  contactDetails {\n    phone\n    email\n    passenger {\n      firstname\n      lastname\n    }\n  }\n  customerSupport {\n    hasGuaranteeChat\n  }\n  upcomingLeg(guarantee: KIWICOM) {\n    arrival {\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    departure {\n      airport {\n        city {\n          name\n        }\n        code\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Header_booking on BookingInterface {\n  type\n  status\n  databaseId\n  ...OneWay_bookingHeader\n  ...Return_bookingHeader\n  ...Multicity_bookingHeader\n}\n\nfragment OneWayTrip_booking on BookingOneWay {\n  trip {\n    ...AccordionTripSummary_trip\n  }\n}\n\nfragment ReturnTrip_booking on BookingReturn {\n  outbound {\n    ...AccordionTripSummary_trip\n  }\n  inbound {\n    ...AccordionTripSummary_trip\n  }\n}\n\nfragment MulticityOverlayTrip_booking on BookingMulticity {\n  trips {\n    duration\n  }\n  ...MulticityTrip_booking\n}\n\nfragment MulticityTrip_booking on BookingMulticity {\n  trips {\n    ...AccordionTripSummary_trip\n  }\n}\n\nfragment AccordionTripSummary_trip on Trip {\n  departure {\n    localTime\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n  arrival {\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n  legs {\n    airline {\n      name\n      code\n      logoUrl\n    }\n    ...CarrierLogoWrapper_legs\n    ...AccordionBody_legs\n    id\n  }\n}\n\nfragment CarrierLogoWrapper_legs on Leg {\n  airline {\n    name\n    code\n  }\n}\n\nfragment AccordionBody_legs on Leg {\n  flightNumber\n  ...AccordionBodyLeg_leg\n  ...AccordionBodyLeg_nextLeg\n  ...AccordionBodyLastLeg_leg\n}\n\nfragment AccordionBodyLeg_leg on Leg {\n  ...AccordionLegCities_leg\n  ...AccordionLegTypeIcon_leg\n  arrival {\n    time\n    localTime\n  }\n  departure {\n    time\n    localTime\n  }\n}\n\nfragment AccordionBodyLeg_nextLeg on Leg {\n  departure {\n    time\n  }\n  guarantee\n}\n\nfragment AccordionBodyLastLeg_leg on Leg {\n  ...AccordionLegCities_leg\n  ...AccordionLegTypeIcon_leg\n  departure {\n    localTime\n  }\n}\n\nfragment AccordionLegCities_leg on Leg {\n  ...AccordionLegCitiesInfo_leg\n  type\n  duration\n  airline {\n    code\n    name\n  }\n  arrival {\n    localTime\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n  departure {\n    localTime\n    airport {\n      locationId\n      city {\n        name\n      }\n      id\n    }\n  }\n}\n\nfragment AccordionLegTypeIcon_leg on Leg {\n  type\n}\n\nfragment AccordionLegCitiesInfo_leg on Leg {\n  type\n  airline {\n    code\n    name\n  }\n  operatingAirline {\n    iata\n    name\n  }\n  flightNumber\n  vehicle {\n    manufacturer\n    model\n  }\n  pnr\n  departure {\n    airport {\n      name\n      id\n    }\n  }\n  arrival {\n    airport {\n      name\n      id\n    }\n  }\n}\n\nfragment OneWay_bookingHeader on BookingOneWay {\n  trip {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n    arrival {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Return_bookingHeader on BookingReturn {\n  outbound {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n    arrival {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Multicity_bookingHeader on BookingMulticity {\n  trips {\n    departure {\n      airport {\n        city {\n          name\n        }\n        id\n      }\n    }\n  }\n  end {\n    airport {\n      city {\n        name\n      }\n      id\n    }\n  }\n}\n",
   "metadata": {},
   "fragment": {
     "kind": "Fragment",
@@ -1090,13 +1105,14 @@ return {
             "concreteType": "BookingOneWay",
             "plural": false,
             "selections": [
-              v17,
+              v16,
               v2,
+              v17,
               v18,
               v19,
               v20,
               v21,
-              v22,
+              v23,
               v24,
               v25,
               v6,
@@ -1113,17 +1129,18 @@ return {
             "concreteType": "BookingReturn",
             "plural": false,
             "selections": [
+              v26,
               v2,
-              v6,
+              v17,
               v18,
               v19,
               v20,
+              v23,
               v21,
-              v22,
-              v26,
               v24,
               v28,
               v25,
+              v6,
               v35,
               v34
             ]
@@ -1137,21 +1154,22 @@ return {
             "concreteType": "BookingMulticity",
             "plural": false,
             "selections": [
+              v30,
               v2,
-              v6,
+              v17,
               v18,
               v19,
               v20,
-              v21,
+              v23,
               v24,
-              v22,
-              v30,
+              v21,
               v31,
               v32,
               v33,
               v25,
-              v29,
-              v35
+              v6,
+              v35,
+              v29
             ]
           },
           v6

--- a/src/relay/__generated__/GuaranteeNeededResolver_booking.graphql.js
+++ b/src/relay/__generated__/GuaranteeNeededResolver_booking.graphql.js
@@ -9,7 +9,6 @@
 /*::
 import type { ConcreteFragment } from 'relay-runtime';
 export type BookingStatus = ('CANCELLED' | 'CLOSED' | 'CONFIRMED' | 'DELETED' | 'EXPIRED' | 'NEW' | 'PENDING' | 'REFUNDED' | '%future added value');
-export type CoveredBy = ('CARRIER' | 'KIWICOM' | '%future added value');
 import type { FragmentReference } from 'relay-runtime';
 declare export opaque type GuaranteeNeededResolver_booking$ref: FragmentReference;
 export type GuaranteeNeededResolver_booking = {|
@@ -23,10 +22,11 @@ export type GuaranteeNeededResolver_booking = {|
       +lastname: ?string,
     |},
   |},
+  +customerSupport: ?{|
+    +hasGuaranteeChat: ?boolean,
+  |},
   +upcomingLeg: ?{|
-    +guarantee: ?CoveredBy,
     +arrival: ?{|
-      +time: ?any,
       +airport: ?{|
         +city: ?{|
           +name: ?string,
@@ -35,7 +35,6 @@ export type GuaranteeNeededResolver_booking = {|
       |},
     |},
     +departure: ?{|
-      +time: ?any,
       +airport: ?{|
         +city: ?{|
           +name: ?string,
@@ -51,13 +50,6 @@ export type GuaranteeNeededResolver_booking = {|
 
 const node/*: ConcreteFragment*/ = (function(){
 var v0 = [
-  {
-    "kind": "ScalarField",
-    "alias": null,
-    "name": "time",
-    "args": null,
-    "storageKey": null
-  },
   {
     "kind": "LinkedField",
     "alias": null,
@@ -169,6 +161,24 @@ return {
     {
       "kind": "LinkedField",
       "alias": null,
+      "name": "customerSupport",
+      "storageKey": null,
+      "args": null,
+      "concreteType": "BookingCustomerSupport",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "ScalarField",
+          "alias": null,
+          "name": "hasGuaranteeChat",
+          "args": null,
+          "storageKey": null
+        }
+      ]
+    },
+    {
+      "kind": "LinkedField",
+      "alias": null,
       "name": "upcomingLeg",
       "storageKey": "upcomingLeg(guarantee:\"KIWICOM\")",
       "args": [
@@ -182,13 +192,6 @@ return {
       "concreteType": "Leg",
       "plural": false,
       "selections": [
-        {
-          "kind": "ScalarField",
-          "alias": null,
-          "name": "guarantee",
-          "args": null,
-          "storageKey": null
-        },
         {
           "kind": "LinkedField",
           "alias": null,
@@ -214,5 +217,5 @@ return {
   ]
 };
 })();
-(node/*: any*/).hash = '92c9d3d84ef33bc07e2231192e163745';
+(node/*: any*/).hash = 'c5f295c3d55615ae5bf9c5b7ed4d2365';
 module.exports = node;

--- a/src/relay/__tests__/GuaranteeNeededResolver.test.js
+++ b/src/relay/__tests__/GuaranteeNeededResolver.test.js
@@ -19,20 +19,20 @@ const commonFields = {
 };
 
 describe('GuaranteeNeededResolver', () => {
-  it('turn on Guarantee chat with departure in less than 4 hours', () => {
+  it(`turn on Guarantee chat when it's not supported for booking`, () => {
     const booking = {
       $refType: mockRefType,
       ...commonFields,
       upcomingLeg: {
         departure: {
-          time: '2018-08-29T22:23:56.311Z',
           airport: null,
         },
         arrival: {
-          time: '2018-08-30T06:23:56.311Z',
           airport: null,
         },
-        guarantee: 'KIWICOM',
+      },
+      customerSupport: {
+        hasGuaranteeChat: true,
       },
     };
     const toggleGuaranteeChat = jest.fn();
@@ -50,113 +50,20 @@ describe('GuaranteeNeededResolver', () => {
     expect(toggleGuaranteeChat).toBeCalledWith(true);
   });
 
-  it('turn on Guarantee chat in time between departure and arrival', () => {
+  it(`does not turn on Guarantee when it's not supported for booking`, () => {
     const booking = {
       $refType: mockRefType,
       ...commonFields,
       upcomingLeg: {
         departure: {
-          time: '2018-08-29T19:23:56.311Z',
           airport: null,
         },
         arrival: {
-          time: '2018-08-30T06:23:56.311Z',
           airport: null,
         },
-        guarantee: 'KIWICOM',
       },
-    };
-    const toggleGuaranteeChat = jest.fn();
-
-    shallow(
-      <UnwrappedGuaranteeNeededResolver
-        booking={booking}
-        showGuaranteeChat={false}
-        guaranteeChatBookingInfo={null}
-        toggleGuaranteeChat={toggleGuaranteeChat}
-        onSetBookingInfo={jest.fn()}
-      />,
-    );
-
-    expect(toggleGuaranteeChat).toBeCalledWith(true);
-  });
-
-  it('does not turn on Guarantee chat with arrival in past', () => {
-    const booking = {
-      $refType: mockRefType,
-      ...commonFields,
-      upcomingLeg: {
-        departure: {
-          time: '2018-08-22T22:23:56.311Z',
-          airport: null,
-        },
-        arrival: {
-          time: '2018-08-23T06:23:56.311Z',
-          airport: null,
-        },
-        guarantee: 'KIWICOM',
-      },
-    };
-    const toggleGuaranteeChat = jest.fn();
-
-    shallow(
-      <UnwrappedGuaranteeNeededResolver
-        booking={booking}
-        showGuaranteeChat={false}
-        guaranteeChatBookingInfo={null}
-        toggleGuaranteeChat={toggleGuaranteeChat}
-        onSetBookingInfo={jest.fn()}
-      />,
-    );
-
-    expect(toggleGuaranteeChat).not.toBeCalled();
-  });
-
-  it('does not turn on Guarantee with departure in more than 4 hours', () => {
-    const booking = {
-      $refType: mockRefType,
-      ...commonFields,
-      upcomingLeg: {
-        departure: {
-          time: '2018-08-30T22:23:56.311Z',
-          airport: null,
-        },
-        arrival: {
-          time: '2018-08-31T06:23:56.311Z',
-          airport: null,
-        },
-        guarantee: 'KIWICOM',
-      },
-    };
-    const toggleGuaranteeChat = jest.fn();
-
-    shallow(
-      <UnwrappedGuaranteeNeededResolver
-        booking={booking}
-        showGuaranteeChat={false}
-        guaranteeChatBookingInfo={null}
-        toggleGuaranteeChat={toggleGuaranteeChat}
-        onSetBookingInfo={jest.fn()}
-      />,
-    );
-
-    expect(toggleGuaranteeChat).not.toBeCalled();
-  });
-
-  it('does not turn on Guarantee chat if not covered by Guarantee', () => {
-    const booking = {
-      $refType: mockRefType,
-      ...commonFields,
-      upcomingLeg: {
-        departure: {
-          time: '2018-08-29T22:23:56.311Z',
-          airport: null,
-        },
-        arrival: {
-          time: '2018-08-30T06:23:56.311Z',
-          airport: null,
-        },
-        guarantee: 'CARRIER',
+      customerSupport: {
+        hasGuaranteeChat: false,
       },
     };
     const toggleGuaranteeChat = jest.fn();


### PR DESCRIPTION
closes #725

This effectively prolong the time when chat can be used => from now on it will be displayed also 4 hours prior the flight that precedes the one covered by the guarantee<br/><br/><br/><url>LiveURL: https://smartfaq-use-graphql-for-chat.surge.sh</url>